### PR TITLE
fix: normalize USPTO ODP search response to results/totalHits contract

### DIFF
--- a/mcp_server/uspto_api.py
+++ b/mcp_server/uspto_api.py
@@ -254,6 +254,12 @@ class USPTOClient:
                     f"Response text: {response.text[:200]}"
                 )
 
+            # Normalize the current USPTO ODP search envelope
+            # (patentFileWrapperDataBag/count) to the documented client contract
+            # (results/totalHits) before logging, empty-result diagnostics, and the
+            # return so every consumer sees a stable response shape.
+            result = self._normalize_search_response(result)
+
             # Log successful response
             if logger:
                 result_count = len(result.get("results", [])) if isinstance(result, dict) else 0
@@ -323,6 +329,17 @@ class USPTOClient:
                 )
             # Catch-all for other request errors
             raise USPTOAPIError(f"Request failed: {e}\n" f"URL: {url}\n" f"Method: {method}")
+
+    @staticmethod
+    def _normalize_search_response(result: dict[str, Any]) -> dict[str, Any]:
+        """Normalize current USPTO ODP search envelope to the client contract."""
+        if not isinstance(result, dict) or "patentFileWrapperDataBag" not in result:
+            return result
+
+        normalized = dict(result)
+        normalized.setdefault("results", result.get("patentFileWrapperDataBag") or [])
+        normalized.setdefault("totalHits", result.get("count", 0))
+        return normalized
 
     def search_patents(
         self,

--- a/mcp_server/uspto_api.py
+++ b/mcp_server/uspto_api.py
@@ -338,7 +338,13 @@ class USPTOClient:
 
         normalized = dict(result)
         normalized.setdefault("results", result.get("patentFileWrapperDataBag") or [])
-        normalized.setdefault("totalHits", result.get("count", 0))
+        # The ODP applications/search envelope carries the total match count under
+        # "totalNumFound" (not "count"). "count" is retained as a defensive fallback
+        # for any sibling endpoint variant, with the page-length as a last resort.
+        total = result.get("totalNumFound")
+        if total is None:
+            total = result.get("count", len(normalized["results"]))
+        normalized.setdefault("totalHits", total)
         return normalized
 
     def search_patents(

--- a/tests/test_uspto_api.py
+++ b/tests/test_uspto_api.py
@@ -4,9 +4,16 @@ from mcp_server.uspto_api import USPTOClient
 
 
 def test_normalize_current_odp_search_response():
-    """The current ODP search envelope is mapped onto the results/totalHits contract."""
+    """The real ODP search envelope is mapped onto the results/totalHits contract.
+
+    The live ``applications/search`` envelope carries the total under
+    ``totalNumFound`` and the records under ``patentFileWrapperDataBag``; there
+    is no ``count`` key. A realistic paginated response returns far fewer
+    records than the total, so ``totalHits`` must come from ``totalNumFound``,
+    not from the length of the returned page.
+    """
     raw = {
-        "count": 1,
+        "totalNumFound": 4231,
         "patentFileWrapperDataBag": [
             {
                 "applicationNumberText": "18045436",
@@ -21,7 +28,7 @@ def test_normalize_current_odp_search_response():
 
     normalized = USPTOClient._normalize_search_response(raw)
 
-    assert normalized["totalHits"] == 1
+    assert normalized["totalHits"] == 4231
     assert normalized["results"] == raw["patentFileWrapperDataBag"]
     # Original envelope keys are preserved alongside the normalized ones.
     assert normalized["patentFileWrapperDataBag"] == raw["patentFileWrapperDataBag"]
@@ -30,11 +37,26 @@ def test_normalize_current_odp_search_response():
 def test_normalize_empty_databag_yields_empty_results():
     """A missing/empty data bag normalizes to an empty result list and zero hits."""
     normalized = USPTOClient._normalize_search_response(
-        {"count": 0, "patentFileWrapperDataBag": []}
+        {"totalNumFound": 0, "patentFileWrapperDataBag": []}
     )
 
     assert normalized["results"] == []
     assert normalized["totalHits"] == 0
+
+
+def test_normalize_total_falls_back_to_page_length_when_total_absent():
+    """If neither totalNumFound nor count is present, fall back to the page length."""
+    raw = {
+        "patentFileWrapperDataBag": [
+            {"applicationNumberText": "1"},
+            {"applicationNumberText": "2"},
+        ]
+    }
+
+    normalized = USPTOClient._normalize_search_response(raw)
+
+    assert normalized["results"] == raw["patentFileWrapperDataBag"]
+    assert normalized["totalHits"] == 2
 
 
 def test_normalize_does_not_override_existing_contract_keys():

--- a/tests/test_uspto_api.py
+++ b/tests/test_uspto_api.py
@@ -1,0 +1,58 @@
+"""Tests for USPTO ODP client helpers."""
+
+from mcp_server.uspto_api import USPTOClient
+
+
+def test_normalize_current_odp_search_response():
+    """The current ODP search envelope is mapped onto the results/totalHits contract."""
+    raw = {
+        "count": 1,
+        "patentFileWrapperDataBag": [
+            {
+                "applicationNumberText": "18045436",
+                "applicationMetaData": {
+                    "patentNumber": "12000000",
+                    "inventionTitle": "Labeled nucleotide analogs",
+                },
+            }
+        ],
+        "requestIdentifier": "request-id",
+    }
+
+    normalized = USPTOClient._normalize_search_response(raw)
+
+    assert normalized["totalHits"] == 1
+    assert normalized["results"] == raw["patentFileWrapperDataBag"]
+    # Original envelope keys are preserved alongside the normalized ones.
+    assert normalized["patentFileWrapperDataBag"] == raw["patentFileWrapperDataBag"]
+
+
+def test_normalize_empty_databag_yields_empty_results():
+    """A missing/empty data bag normalizes to an empty result list and zero hits."""
+    normalized = USPTOClient._normalize_search_response(
+        {"count": 0, "patentFileWrapperDataBag": []}
+    )
+
+    assert normalized["results"] == []
+    assert normalized["totalHits"] == 0
+
+
+def test_normalize_does_not_override_existing_contract_keys():
+    """Pre-existing results/totalHits values are left untouched."""
+    raw = {
+        "patentFileWrapperDataBag": [{"applicationNumberText": "1"}],
+        "results": [{"applicationNumberText": "already-normalized"}],
+        "totalHits": 42,
+    }
+
+    normalized = USPTOClient._normalize_search_response(raw)
+
+    assert normalized["results"] == [{"applicationNumberText": "already-normalized"}]
+    assert normalized["totalHits"] == 42
+
+
+def test_normalize_passes_through_non_search_payloads():
+    """Payloads without the search data bag are returned unchanged."""
+    raw = {"someOtherKey": "value"}
+
+    assert USPTOClient._normalize_search_response(raw) is raw


### PR DESCRIPTION
## Problem
`USPTOClient._make_request` returns the raw USPTO Open Data Portal search
envelope, which carries results under `patentFileWrapperDataBag` and the match
count under `count`. Every caller, however, reads `results` / `totalHits`:
`search_patents_simple`, `get_patent_by_number`, `get_patent_by_application`,
`get_recent_patents`, and `check_api_status_detailed`. The result is that
searches silently return zero results even when the API responds with matches.

## Fix
Add `USPTOClient._normalize_search_response`, applied in `_make_request`
immediately after JSON parsing, which maps the current ODP envelope onto the
documented `results` / `totalHits` contract. It runs before the success log
and empty-result diagnostics so they observe a stable shape too. Existing
`results` / `totalHits` keys are never overwritten, and non-search payloads
pass through unchanged.

## Tests
Adds `tests/test_uspto_api.py` covering the envelope mapping, empty data bag,
no-override of pre-existing keys, and passthrough of non-search payloads.
`ruff check` is clean on the changed files; the new tests pass.
