### PR TITLE
fix: route pre-Turing NVIDIA GPUs to cu126 PyTorch build

### DIFF
--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -188,6 +188,22 @@ Your driver (581.80) supports:
 | CUDA 12.8 | `https://download.pytorch.org/whl/cu128` | ≥R555 | ✓ **Installed** |
 | CUDA 13.0 | `https://download.pytorch.org/whl/cu130` | ≥R560 | ✓ Supported |
 
+### GPU architecture and wheel selection
+
+The CUDA wheel is chosen automatically from your GPU's **compute capability**
+(detected via `nvidia-smi`), because the `cu128` wheels only ship compiled
+kernels for **Turing (sm_75) and newer**:
+
+| GPU architecture | Example cards | Compute capability | PyTorch wheel |
+|------------------|---------------|--------------------|---------------|
+| Blackwell / Ada / Ampere / Turing | RTX 50/40/30 series, RTX 20 series | ≥ 7.5 | `cu128` |
+| Pascal / Volta / Maxwell | GTX 10 series, Titan X, Tesla V100 | < 7.5 | `cu126` (torch 2.7.1) |
+
+Pre-Turing cards routed to `cu128` crash at kernel launch with
+`CUDA error: no kernel image is available for execution on the device`. The
+`cu126` build of torch 2.7.1 still bundles `sm_50`–`sm_90`, so those GPUs are
+sent there automatically.
+
 ## Troubleshooting
 
 ### "CUDA out of memory" errors
@@ -208,6 +224,27 @@ python -c "import torch; print(f'CUDA: {torch.cuda.is_available()}')"
 pip uninstall torch torchvision
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
 ```
+
+### "no kernel image is available for execution on the device"
+
+Your PyTorch build has no compiled kernels for your GPU's architecture —
+typically a pre-Turing card (GTX 10-series and older, compute capability < 7.5)
+that received a `cu128` build. Reinstall the `cu126` build, which includes
+`sm_50`–`sm_90`:
+
+```powershell
+pip uninstall -y torch torchvision
+pip install torch==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu126
+```
+
+Confirm your GPU's architecture is now supported:
+
+```powershell
+python -c "import torch; print(torch.cuda.get_arch_list())"
+```
+
+`patent-creator setup` selects the correct wheel automatically, so this is only
+needed for manual installs.
 
 ### Multiple Python installations conflict
 

--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -99,8 +99,10 @@ def install_pytorch():
     except Exception:
         pass  # Ignore errors
 
-    # Build pip install command
-    cmd = [sys.executable, "-m", "pip", "install", package_spec]
+    # Build pip install command. package_spec may contain multiple
+    # whitespace-separated requirements (e.g. pinned torch + torchvision for
+    # legacy GPUs), so split it into individual pip arguments.
+    cmd = [sys.executable, "-m", "pip", "install", *package_spec.split()]
     if index_url:
         cmd.extend(["--index-url", index_url])
 

--- a/mcp_server/hardware_detect.py
+++ b/mcp_server/hardware_detect.py
@@ -4,6 +4,7 @@ Hardware detection for automatic PyTorch installation
 Detects GPU type and determines correct PyTorch version
 """
 
+import contextlib
 import platform
 import subprocess
 
@@ -18,9 +19,15 @@ def detect_nvidia_gpu():
 
 
 def get_nvidia_compute_capability():
-    """Return the highest NVIDIA GPU compute capability as a float, or None.
+    """Return the LOWEST NVIDIA GPU compute capability as a float, or None.
 
-    e.g. GTX 1080 (Pascal) -> 6.1, RTX 3090 (Ampere) -> 8.6, RTX 5090 -> 12.0
+    nvidia-smi reports one compute_cap per GPU. We return the minimum so the
+    oldest card in the system drives wheel selection: cu126 covers sm_50-sm_90,
+    so if any GPU is pre-Turing the whole system must use cu126. Non-numeric
+    lines (warnings, headers) are skipped rather than failing detection.
+
+    e.g. GTX 1080 (Pascal) -> 6.1, RTX 3090 (Ampere) -> 8.6, RTX 5090 -> 12.0;
+    a mixed 6.1 + 8.6 system -> 6.1.
     """
     try:
         result = subprocess.run(
@@ -30,10 +37,15 @@ def get_nvidia_compute_capability():
             timeout=5,
         )
         if result.returncode == 0:
-            caps = [float(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+            caps = []
+            for line in result.stdout.splitlines():
+                cleaned = line.strip()
+                if cleaned:
+                    with contextlib.suppress(ValueError):
+                        caps.append(float(cleaned))
             if caps:
-                return max(caps)
-    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+                return min(caps)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
     return None
 
@@ -126,15 +138,21 @@ def check_pytorch_installation():
         # architectures this PyTorch build was compiled for.
         if has_nvidia and cuda_available:
             try:
-                major, minor = torch.cuda.get_device_capability(0)
-                cap_tag = f"sm_{major}{minor}"
                 arch_list = torch.cuda.get_arch_list()
-                if arch_list and cap_tag not in arch_list:
-                    status["hardware_match"] = False
-                    status["warning"] = (
-                        f"PyTorch {torch.__version__} has no compiled kernels for "
-                        f"this GPU ({cap_tag}); build supports {arch_list}"
-                    )
+                if arch_list:
+                    # Check every CUDA device: device 0 may be supported while a
+                    # second, older GPU in the system is not.
+                    for i in range(torch.cuda.device_count()):
+                        major, minor = torch.cuda.get_device_capability(i)
+                        cap_tag = f"sm_{major}{minor}"
+                        if cap_tag not in arch_list:
+                            status["hardware_match"] = False
+                            status["warning"] = (
+                                f"PyTorch {torch.__version__} has no compiled kernels "
+                                f"for GPU {i} ({torch.cuda.get_device_name(i)}, "
+                                f"{cap_tag}); build supports {arch_list}"
+                            )
+                            break
             except Exception:
                 pass
 

--- a/mcp_server/hardware_detect.py
+++ b/mcp_server/hardware_detect.py
@@ -17,6 +17,27 @@ def detect_nvidia_gpu():
         return False
 
 
+def get_nvidia_compute_capability():
+    """Return the highest NVIDIA GPU compute capability as a float, or None.
+
+    e.g. GTX 1080 (Pascal) -> 6.1, RTX 3090 (Ampere) -> 8.6, RTX 5090 -> 12.0
+    """
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            caps = [float(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+            if caps:
+                return max(caps)
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        pass
+    return None
+
+
 def detect_apple_silicon():
     """Detect if running on Apple Silicon (M1/M2/M3)"""
     if platform.system() != "Darwin":
@@ -41,6 +62,19 @@ def get_pytorch_install_command():
     has_apple_silicon = detect_apple_silicon()
 
     if has_nvidia:
+        compute_cap = get_nvidia_compute_capability()
+        # cu128 wheels only ship compiled kernels for sm_75+ (Turing and newer).
+        # Pre-Turing cards (Pascal sm_61, Volta sm_70, Maxwell sm_5x) get a
+        # "no kernel image is available for execution on the device" error with
+        # cu128. The cu126 build of torch 2.7.1 still bundles sm_50..sm_90, so
+        # route older GPUs there. Unknown capability falls through to cu128.
+        if compute_cap is not None and compute_cap < 7.5:
+            return (
+                "torch==2.7.1 torchvision==0.22.1",
+                "https://download.pytorch.org/whl/cu126",
+                f"[GPU] NVIDIA GPU (compute {compute_cap}) detected - installing "
+                "PyTorch 2.7.1 with CUDA 12.6 (legacy GPU architecture support)",
+            )
         return (
             "torch>=2.0.0",
             "https://download.pytorch.org/whl/cu128",
@@ -84,6 +118,25 @@ def check_pytorch_installation():
         if has_nvidia and not cuda_available:
             status["hardware_match"] = False
             status["warning"] = "NVIDIA GPU detected but PyTorch has no CUDA support"
+
+        # CUDA can report "available" while still lacking compiled kernels for
+        # this specific GPU architecture. That manifests at kernel-launch time
+        # as "no kernel image is available for execution on the device". Detect
+        # it up front by checking the device's compute capability against the
+        # architectures this PyTorch build was compiled for.
+        if has_nvidia and cuda_available:
+            try:
+                major, minor = torch.cuda.get_device_capability(0)
+                cap_tag = f"sm_{major}{minor}"
+                arch_list = torch.cuda.get_arch_list()
+                if arch_list and cap_tag not in arch_list:
+                    status["hardware_match"] = False
+                    status["warning"] = (
+                        f"PyTorch {torch.__version__} has no compiled kernels for "
+                        f"this GPU ({cap_tag}); build supports {arch_list}"
+                    )
+            except Exception:
+                pass
 
         # Check if Apple Silicon
         if detect_apple_silicon():

--- a/mcp_server/hardware_detect.py
+++ b/mcp_server/hardware_detect.py
@@ -6,6 +6,7 @@ Detects GPU type and determines correct PyTorch version
 
 import contextlib
 import platform
+import re
 import subprocess
 
 
@@ -45,7 +46,7 @@ def get_nvidia_compute_capability():
                         caps.append(float(cleaned))
             if caps:
                 return min(caps)
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (subprocess.TimeoutExpired, OSError):
         pass
     return None
 
@@ -140,17 +141,32 @@ def check_pytorch_installation():
             try:
                 arch_list = torch.cuda.get_arch_list()
                 if arch_list:
+                    # Parse the build's compiled architectures into (major, minor)
+                    # pairs. PyTorch wheels list baselines (e.g. sm_80, sm_86) and
+                    # rely on intra-major backward compatibility, so an exact
+                    # sm_XX string match would false-positive on minor versions
+                    # not explicitly listed (e.g. sm_89 / RTX 40-series).
+                    supported = []
+                    for arch in arch_list:
+                        m = re.match(r"^(?:sm|compute)_(\d+)(\d)[a-z]?$", arch)
+                        if m:
+                            supported.append((int(m.group(1)), int(m.group(2))))
                     # Check every CUDA device: device 0 may be supported while a
-                    # second, older GPU in the system is not.
+                    # second, older GPU in the system is not. A device is
+                    # compatible when the build has a kernel with the same major
+                    # version and a minor <= the device's minor (NVIDIA guarantees
+                    # backward compatibility within a major architecture).
                     for i in range(torch.cuda.device_count()):
                         major, minor = torch.cuda.get_device_capability(i)
-                        cap_tag = f"sm_{major}{minor}"
-                        if cap_tag not in arch_list:
+                        compatible = any(
+                            a_major == major and a_minor <= minor for a_major, a_minor in supported
+                        )
+                        if not compatible:
                             status["hardware_match"] = False
                             status["warning"] = (
                                 f"PyTorch {torch.__version__} has no compiled kernels "
                                 f"for GPU {i} ({torch.cuda.get_device_name(i)}, "
-                                f"{cap_tag}); build supports {arch_list}"
+                                f"sm_{major}{minor}); build supports {arch_list}"
                             )
                             break
             except Exception:

--- a/mcp_server/hardware_detect.py
+++ b/mcp_server/hardware_detect.py
@@ -151,24 +151,29 @@ def check_pytorch_installation():
                         m = re.match(r"^(?:sm|compute)_(\d+)(\d)[a-z]?$", arch)
                         if m:
                             supported.append((int(m.group(1)), int(m.group(2))))
+                    # Only evaluate compatibility if at least one architecture
+                    # parsed; an empty list (unexpected arch_list format) must
+                    # not produce a false mismatch and trigger a reinstall loop.
                     # Check every CUDA device: device 0 may be supported while a
                     # second, older GPU in the system is not. A device is
                     # compatible when the build has a kernel with the same major
                     # version and a minor <= the device's minor (NVIDIA guarantees
                     # backward compatibility within a major architecture).
-                    for i in range(torch.cuda.device_count()):
-                        major, minor = torch.cuda.get_device_capability(i)
-                        compatible = any(
-                            a_major == major and a_minor <= minor for a_major, a_minor in supported
-                        )
-                        if not compatible:
-                            status["hardware_match"] = False
-                            status["warning"] = (
-                                f"PyTorch {torch.__version__} has no compiled kernels "
-                                f"for GPU {i} ({torch.cuda.get_device_name(i)}, "
-                                f"sm_{major}{minor}); build supports {arch_list}"
+                    if supported:
+                        for i in range(torch.cuda.device_count()):
+                            major, minor = torch.cuda.get_device_capability(i)
+                            compatible = any(
+                                a_major == major and a_minor <= minor
+                                for a_major, a_minor in supported
                             )
-                            break
+                            if not compatible:
+                                status["hardware_match"] = False
+                                status["warning"] = (
+                                    f"PyTorch {torch.__version__} has no compiled kernels "
+                                    f"for GPU {i} ({torch.cuda.get_device_name(i)}, "
+                                    f"sm_{major}{minor}); build supports {arch_list}"
+                                )
+                                break
             except Exception:
                 pass
 

--- a/scripts/auto_setup.py
+++ b/scripts/auto_setup.py
@@ -4,6 +4,7 @@ Automatic GPU/CPU Detection and PyTorch Installation
 Detects hardware and installs the correct PyTorch version automatically
 """
 
+import contextlib
 import platform
 import subprocess
 import sys
@@ -43,9 +44,18 @@ def get_compute_capability():
             timeout=5,
         )
         if result.returncode == 0:
-            compute_cap = result.stdout.strip()
-            if compute_cap:
-                return float(compute_cap)
+            # nvidia-smi emits one compute_cap per GPU; parse each line and
+            # return the MINIMUM so the oldest GPU in the system drives wheel
+            # selection (cu126 covers sm_50-sm_90). Non-numeric lines (warnings,
+            # headers) are skipped rather than failing the whole detection.
+            caps = []
+            for line in result.stdout.splitlines():
+                cleaned = line.strip()
+                if cleaned:
+                    with contextlib.suppress(ValueError):
+                        caps.append(float(cleaned))
+            if caps:
+                return min(caps)
     except Exception:
         pass
     return None

--- a/scripts/auto_setup.py
+++ b/scripts/auto_setup.py
@@ -61,15 +61,20 @@ def install_pytorch(gpu_available=False, compute_cap=None):
         cmd = f"{sys.executable} -m pip install torch torchvision"
         return run_command(cmd, "Installing PyTorch (CPU)")
 
-    # RTX 5090/5080 (compute 12.0+) need CUDA 12.8, older GPUs use 12.8 too
-    if compute_cap and compute_cap >= 10.0:
-        cuda_pkg = "cu128"
-        cuda_name = "12.8"
+    # cu128 wheels only ship kernels for sm_75+ (Turing and newer). Pre-Turing
+    # GPUs (Pascal sm_61, Volta sm_70, Maxwell sm_5x) crash at kernel launch
+    # with "no kernel image is available for execution on the device". For those
+    # we pin the cu126 build of torch 2.7.1, which still bundles sm_50..sm_90.
+    if compute_cap is not None and compute_cap < 7.5:
+        torch_spec = "torch==2.7.1 torchvision==0.22.1"
+        cuda_pkg = "cu126"
+        cuda_name = "12.6"
         print("\n" + "=" * 60)
-        print(f"RTX 5090/5080 detected (Compute {compute_cap}) - Installing CUDA {cuda_name}")
+        print(f"Legacy NVIDIA GPU detected (Compute {compute_cap}) - Installing CUDA {cuda_name}")
         print("=" * 60)
     else:
-        cuda_pkg = "cu128"  # Default to 12.8 for best compatibility
+        torch_spec = "torch torchvision"
+        cuda_pkg = "cu128"  # Turing and newer
         cuda_name = "12.8"
         print("\n" + "=" * 60)
         print(f"NVIDIA GPU detected - Installing CUDA {cuda_name} version")
@@ -82,7 +87,7 @@ def install_pytorch(gpu_available=False, compute_cap=None):
         capture_output=True,
     )
 
-    cmd = f"{sys.executable} -m pip install torch torchvision --index-url https://download.pytorch.org/whl/{cuda_pkg}"
+    cmd = f"{sys.executable} -m pip install {torch_spec} --index-url https://download.pytorch.org/whl/{cuda_pkg}"
     return run_command(cmd, f"Installing PyTorch (CUDA {cuda_name})")
 
 

--- a/scripts/auto_setup.py
+++ b/scripts/auto_setup.py
@@ -90,14 +90,15 @@ def install_pytorch(gpu_available=False, compute_cap=None):
         print(f"NVIDIA GPU detected - Installing CUDA {cuda_name} version")
         print("=" * 60)
 
-    # Uninstall any existing PyTorch first
+    # Uninstall any existing PyTorch first. Quote sys.executable so a venv path
+    # containing spaces (e.g. C:\Users\John Doe\venv) survives shell=True.
     subprocess.run(
-        f"{sys.executable} -m pip uninstall -y torch torchvision torchaudio",
+        f'"{sys.executable}" -m pip uninstall -y torch torchvision torchaudio',
         shell=True,
         capture_output=True,
     )
 
-    cmd = f"{sys.executable} -m pip install {torch_spec} --index-url https://download.pytorch.org/whl/{cuda_pkg}"
+    cmd = f'"{sys.executable}" -m pip install {torch_spec} --index-url https://download.pytorch.org/whl/{cuda_pkg}'
     return run_command(cmd, f"Installing PyTorch (CUDA {cuda_name})")
 
 


### PR DESCRIPTION
## Description

Routes pre-Turing NVIDIA GPUs to a PyTorch build that actually contains kernels for them. The `cu128` wheels only ship `sm_75`+ kernels, so Pascal / Volta / Maxwell cards crash at the first CUDA kernel launch with `no kernel image is available for execution on the device`. This selects the `cu126` build (torch 2.7.1, which bundles `sm_50`–`sm_90`) for GPUs with compute capability `< 7.5`, keeps `cu128` for Turing and newer, and makes the hardware-match check architecture-aware.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Fixes #25

On a GTX 1080 (sm_61), `patent-creator setup` installed `torch …+cu128`, whose `torch.cuda.get_arch_list()` is `['sm_75','sm_80','sm_86','sm_90','sm_100','sm_120']` — no `sm_61` — so index building crashed at the first GPU kernel launch. `check_pytorch_installation()` reported a hardware match because `torch.cuda.is_available()` returns `True` even without matching kernels, so the failure only surfaced at runtime.

## How Has This Been Tested?

- [x] Tests pass locally
- [x] Manual testing performed

**Test Configuration:**
- OS: Windows 10
- Python version: 3.12
- GPU: NVIDIA GeForce GTX 1080 (sm_61)

Verified on the affected hardware: after the fix, `get_pytorch_install_command()` returns the cu126 / torch 2.7.1 build for the GTX 1080; `torch.cuda.get_arch_list()` then includes `sm_61`; a real GPU matmul and the BGE embedding step (the one that was crashing) run on CUDA; and `check_pytorch_installation()` now reports a mismatch when the device capability is absent from the arch list. `ruff`/`black` are clean on the changed files and `pytest -m "not slow and not gpu and not api"` passes (35 tests).

## Changes Made

- `mcp_server/hardware_detect.py`: add `get_nvidia_compute_capability()`; route compute `< 7.5` to `cu126` (torch 2.7.1); make `check_pytorch_installation()` compare the device capability against `torch.cuda.get_arch_list()`.
- `mcp_server/cli.py`: split the multi-package torch spec into individual pip arguments.
- `scripts/auto_setup.py`: same compute-capability-based cu126 / cu128 routing.
- `docs/GPU_SETUP.md`: document architecture → wheel selection and add a troubleshooting entry for the error.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation Updates

- [ ] README.md updated
- [ ] CLAUDE.md updated
- [ ] CHANGELOG.md updated (if applicable)
- [x] docs/GPU_SETUP.md updated

---

Note on tests: this change lives in the installer's hardware-detection path (`nvidia-smi` subprocess + pip invocation), which the existing suite doesn't harness, so it was verified manually on the affected hardware as described above. Happy to add a unit test that mocks `nvidia-smi` compute-cap output if you'd prefer one before merge.
