### PR TITLE
fix: macOS Apple Silicon install gotchas (SSL, PATENT_MPEP_DEVICE, MPS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - CONTRIBUTING.md and SECURITY.md
 
 ### Fixed
+- `downloaders`: MPEP/USPTO downloads now verify TLS against the bundled `certifi`
+  CA store, fixing `SSL: CERTIFICATE_VERIFY_FAILED` on python.org macOS Python (#23)
+- `utils/device`: honor the documented `PATENT_MPEP_DEVICE` env var (`cpu`/`gpu`/
+  `mps`), which was referenced in docs but never read; `FORCE_CPU` still works (#23)
+- `utils/device`: detect Apple Silicon (MPS) and stay on CPU by default — MPS runs
+  the BGE embedding workload ~50x slower; opt in with `PATENT_MPEP_DEVICE=mps` (#23)
 - `analyzer_base`: WARNING/INFO severity levels now in SEVERITY_ORDER (prevents KeyError)
 - `base_index`: Guard against FAISS returning -1 for unfound results
 - `base_index`: Guard against empty candidates in reranker

--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -273,6 +273,37 @@ EMBED_BATCH_SIZE=16 patent-creator rebuild-index
 ```
 Default batch size may be too large for GPUs with less VRAM. Try 16 or 8.
 
+## macOS / Apple Silicon
+
+On Apple Silicon (M-series) Macs, the embedding and reranker models run on **CPU
+by default** — and that is intentional. Apple's Metal (MPS) backend runs the
+BGE-base embedding workload roughly **50x slower** than CPU, so CPU is the
+faster choice here. The setup auto-detects this and stays on CPU.
+
+If you have a specific reason to use MPS anyway, opt in explicitly:
+```bash
+PATENT_MPEP_DEVICE=mps patent-creator setup --rebuild --non-interactive
+```
+
+To force CPU explicitly (either of these works):
+```bash
+FORCE_CPU=1 patent-creator setup --rebuild --non-interactive
+# or, equivalently:
+PATENT_MPEP_DEVICE=cpu patent-creator setup --rebuild --non-interactive
+```
+
+### `SSL: CERTIFICATE_VERIFY_FAILED` when downloading MPEP
+
+If the MPEP download fails with `[SSL: CERTIFICATE_VERIFY_FAILED] ... unable to
+get local issuer certificate`, you are almost certainly on the python.org macOS
+build of Python, which ships OpenSSL **without** a system CA bundle. The
+downloader now verifies against the bundled `certifi` CA store automatically, so
+this should resolve itself. If you are on an older build, you can also run the
+one-time fix that ships with the installer:
+```bash
+/Applications/Python\ 3.11/Install\ Certificates.command
+```
+
 ## Support
 
 If you encounter issues:

--- a/mcp_server/downloaders.py
+++ b/mcp_server/downloaders.py
@@ -1,11 +1,30 @@
 """Unified file download utilities for USPTO resources"""
 
 import socket
+import ssl
 import sys
 import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Optional
+
+
+def _create_ssl_context() -> ssl.SSLContext:
+    """Build an SSL context with an explicit CA bundle.
+
+    The python.org macOS installer ships OpenSSL without a system CA bundle, so
+    ``urllib`` downloads from HTTPS hosts (e.g. the USPTO MPEP zip) fail with
+    ``CERTIFICATE_VERIFY_FAILED``. ``certifi`` is available transitively via
+    ``requests``; pointing the context at ``certifi.where()`` fixes verification
+    on those interpreters while remaining correct everywhere else. If ``certifi``
+    is somehow unavailable we fall back to the platform default context.
+    """
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
 
 
 class FileDownloader:
@@ -73,7 +92,26 @@ class FileDownloader:
                     )
 
             try:
-                urllib.request.urlretrieve(url, dest_path, progress_hook)
+                # Stream the download manually (rather than urlretrieve) so we can
+                # pass an explicit SSL context with a certifi CA bundle — required
+                # on python.org's macOS Python, which ships no system CA bundle.
+                ssl_context = _create_ssl_context()
+                request = urllib.request.Request(url)
+                block_size = 8192
+                with urllib.request.urlopen(
+                    request, timeout=timeout_seconds, context=ssl_context
+                ) as response:
+                    total_size = int(response.headers.get("Content-Length", 0) or 0)
+                    block_num = 0
+                    progress_hook(block_num, block_size, total_size)
+                    with dest_path.open("wb") as out_file:
+                        while True:
+                            chunk = response.read(block_size)
+                            if not chunk:
+                                break
+                            out_file.write(chunk)
+                            block_num += 1
+                            progress_hook(block_num, block_size, total_size)
                 print(f"\n[OK] {file_description} download complete", file=sys.stderr)
                 return True
             finally:

--- a/mcp_server/downloaders.py
+++ b/mcp_server/downloaders.py
@@ -103,6 +103,7 @@ class FileDownloader:
                 ) as response:
                     total_size = int(response.headers.get("Content-Length", 0) or 0)
                     block_num = 0
+                    downloaded = 0
                     progress_hook(block_num, block_size, total_size)
                     with dest_path.open("wb") as out_file:
                         while True:
@@ -110,8 +111,14 @@ class FileDownloader:
                             if not chunk:
                                 break
                             out_file.write(chunk)
+                            downloaded += len(chunk)
                             block_num += 1
                             progress_hook(block_num, block_size, total_size)
+                    # Mirror urlretrieve's ContentTooShortError: a stream that ends
+                    # before the advertised Content-Length is a truncated download,
+                    # not a success. Raising routes to the cleanup path below.
+                    if total_size and downloaded < total_size:
+                        raise OSError(f"Download truncated: got {downloaded} of {total_size} bytes")
                 print(f"\n[OK] {file_description} download complete", file=sys.stderr)
                 return True
             finally:

--- a/mcp_server/utils/device.py
+++ b/mcp_server/utils/device.py
@@ -8,32 +8,73 @@ def get_device() -> str:
     """Detect and return the best available device for computation.
 
     Environment variables:
-        FORCE_CPU=1          - Force CPU usage even if GPU is available
+        FORCE_CPU=1          - Force CPU usage even if a GPU/accelerator is available
+        PATENT_MPEP_DEVICE   - Explicit device override. Accepts:
+                                 cpu        -> force CPU (alias for FORCE_CPU)
+                                 gpu / cuda -> prefer CUDA when available
+                                 mps        -> opt in to Apple Silicon MPS
+                                               (NOT recommended; see below)
+                                 auto / ""  -> auto-detect (default)
         CUDA_VISIBLE_DEVICES - Control which GPUs are visible (PyTorch standard)
 
+    Apple Silicon note:
+        MPS (Apple's Metal backend) is detected but deliberately NOT used by
+        default. The BGE embedding workload runs roughly 50x slower on MPS than
+        on CPU, so CPU is the better default. Set PATENT_MPEP_DEVICE=mps to
+        override if you have a specific reason.
+
     Returns:
-        'cuda' if GPU available and not disabled, 'cpu' otherwise
+        'cuda', 'mps', or 'cpu'.
     """
-    # Check if CPU is forced via environment variable
+    device_override = os.environ.get("PATENT_MPEP_DEVICE", "").strip().lower()
     force_cpu = os.environ.get("FORCE_CPU", "0").lower() in ("1", "true", "yes")
 
-    if force_cpu:
-        print("CPU forced via FORCE_CPU environment variable", file=sys.stderr)
+    # Explicit CPU request wins over everything.
+    if force_cpu or device_override == "cpu":
+        reason = "FORCE_CPU" if force_cpu else "PATENT_MPEP_DEVICE=cpu"
+        print(f"CPU forced via {reason} environment variable", file=sys.stderr)
         return "cpu"
 
-    # Check for CUDA availability
     try:
         import torch
-
-        if torch.cuda.is_available():
-            device = "cuda"
-            gpu_name = torch.cuda.get_device_name(0)
-            gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1024**3
-            print(f"GPU detected: {gpu_name} ({gpu_memory:.1f}GB VRAM)", file=sys.stderr)
-            return device
-        else:
-            print("GPU not available, using CPU...", file=sys.stderr)
-            return "cpu"
     except ImportError:
         print("PyTorch not available, using CPU...", file=sys.stderr)
         return "cpu"
+
+    # CUDA (NVIDIA) — the best accelerator when present.
+    if torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1024**3
+        print(f"GPU detected: {gpu_name} ({gpu_memory:.1f}GB VRAM)", file=sys.stderr)
+        return "cuda"
+
+    if device_override in ("gpu", "cuda"):
+        print(
+            "PATENT_MPEP_DEVICE requested CUDA but no CUDA device is available; "
+            "falling back to CPU.",
+            file=sys.stderr,
+        )
+
+    # Apple Silicon (MPS) — available but deliberately gated. MPS runs the BGE
+    # embedding workload dramatically slower than CPU, so CPU is the default
+    # unless the user explicitly opts in with PATENT_MPEP_DEVICE=mps.
+    mps_backend = getattr(torch.backends, "mps", None)
+    mps_available = bool(mps_backend is not None and mps_backend.is_available())
+    if mps_available:
+        if device_override == "mps":
+            print(
+                "Apple Silicon MPS selected via PATENT_MPEP_DEVICE=mps "
+                "(note: typically much slower than CPU for embeddings).",
+                file=sys.stderr,
+            )
+            return "mps"
+        print(
+            "Apple Silicon GPU (MPS) detected but using CPU: MPS is dramatically "
+            "slower than CPU for this embedding workload. Set PATENT_MPEP_DEVICE=mps "
+            "to override.",
+            file=sys.stderr,
+        )
+        return "cpu"
+
+    print("GPU not available, using CPU...", file=sys.stderr)
+    return "cpu"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,75 @@
+"""Tests for device selection (mcp_server.utils.device)."""
+
+import sys
+import types
+
+import pytest
+
+from mcp_server.utils.device import get_device
+
+
+def _fake_torch(*, cuda=False, mps=False):
+    """Build a stand-in ``torch`` module with configurable accelerators.
+
+    ``mps=None`` simulates an older torch with no ``torch.backends.mps`` at all.
+    """
+    torch = types.ModuleType("torch")
+
+    torch.cuda = types.SimpleNamespace(
+        is_available=lambda: cuda,
+        get_device_name=lambda idx: "Fake CUDA Device",
+        get_device_properties=lambda idx: types.SimpleNamespace(total_memory=8 * 1024**3),
+    )
+
+    backends = types.ModuleType("torch.backends")
+    if mps is not None:
+        backends.mps = types.SimpleNamespace(is_available=lambda: mps)
+    torch.backends = backends
+    return torch
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("FORCE_CPU", raising=False)
+    monkeypatch.delenv("PATENT_MPEP_DEVICE", raising=False)
+
+
+def test_force_cpu_env_returns_cpu(monkeypatch):
+    monkeypatch.setenv("FORCE_CPU", "1")
+    # Even with a CUDA device present, FORCE_CPU must win.
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=True))
+    assert get_device() == "cpu"
+
+
+def test_patent_mpep_device_cpu_returns_cpu(monkeypatch):
+    """The documented PATENT_MPEP_DEVICE=cpu override is honored (issue #23)."""
+    monkeypatch.setenv("PATENT_MPEP_DEVICE", "cpu")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=True))
+    assert get_device() == "cpu"
+
+
+def test_cuda_available_returns_cuda(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=True))
+    assert get_device() == "cuda"
+
+
+def test_mps_available_defaults_to_cpu(monkeypatch):
+    """Apple Silicon MPS is gated off by default due to the embedding perf cliff."""
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=False, mps=True))
+    assert get_device() == "cpu"
+
+
+def test_mps_opt_in_returns_mps(monkeypatch):
+    monkeypatch.setenv("PATENT_MPEP_DEVICE", "mps")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=False, mps=True))
+    assert get_device() == "mps"
+
+
+def test_no_accelerator_returns_cpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=False, mps=False))
+    assert get_device() == "cpu"
+
+
+def test_old_torch_without_mps_backend_returns_cpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda=False, mps=None))
+    assert get_device() == "cpu"

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -1,0 +1,36 @@
+"""Tests for download utilities (mcp_server.downloaders)."""
+
+import ssl
+
+import pytest
+
+from mcp_server.downloaders import _create_ssl_context
+
+
+def test_create_ssl_context_returns_verifying_context():
+    """The context must keep certificate verification ON."""
+    ctx = _create_ssl_context()
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+
+
+def test_create_ssl_context_uses_certifi_bundle(monkeypatch):
+    """When certifi is importable, the context is built from its CA bundle.
+
+    This is what fixes CERTIFICATE_VERIFY_FAILED on python.org macOS Python,
+    which ships no system CA bundle (issue #23).
+    """
+    certifi = pytest.importorskip("certifi")
+
+    captured = {}
+    real_create = ssl.create_default_context
+
+    def _spy(*args, **kwargs):
+        captured["cafile"] = kwargs.get("cafile")
+        return real_create(*args, **kwargs)
+
+    monkeypatch.setattr(ssl, "create_default_context", _spy)
+    _create_ssl_context()
+
+    assert captured["cafile"] == certifi.where()

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -1,10 +1,29 @@
 """Tests for download utilities (mcp_server.downloaders)."""
 
+import io
 import ssl
+import urllib.request
 
 import pytest
 
-from mcp_server.downloaders import _create_ssl_context
+from mcp_server.downloaders import FileDownloader, _create_ssl_context
+
+
+class _FakeResponse:
+    """Minimal stand-in for an HTTP response usable as a context manager."""
+
+    def __init__(self, data: bytes, content_length: int):
+        self._buf = io.BytesIO(data)
+        self.headers = {"Content-Length": str(content_length)}
+
+    def read(self, size):
+        return self._buf.read(size)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
 
 
 def test_create_ssl_context_returns_verifying_context():
@@ -34,3 +53,25 @@ def test_create_ssl_context_uses_certifi_bundle(monkeypatch):
     _create_ssl_context()
 
     assert captured["cafile"] == certifi.where()
+
+
+def test_complete_download_succeeds(tmp_path, monkeypatch):
+    dest = tmp_path / "file.zip"
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"x" * 100, 100))
+    ok = FileDownloader.download_with_progress(
+        "https://example.com/file.zip", dest, "test file", timeout_seconds=5
+    )
+    assert ok is True
+    assert dest.read_bytes() == b"x" * 100
+
+
+def test_truncated_download_fails_and_cleans_up(tmp_path, monkeypatch):
+    """A stream shorter than Content-Length must fail and remove the partial file."""
+    dest = tmp_path / "file.zip"
+    # Advertise 100 bytes but only deliver 50.
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"x" * 50, 100))
+    ok = FileDownloader.download_with_progress(
+        "https://example.com/file.zip", dest, "test file", timeout_seconds=5
+    )
+    assert ok is False
+    assert not dest.exists()


### PR DESCRIPTION
Fixes the three macOS Apple Silicon gotchas reported in #23. Thanks to @kieranskelly for the excellent diagnosis — all three were verified against the code.

## 1. `SSL: CERTIFICATE_VERIFY_FAILED` on MPEP download
`FileDownloader.download_with_progress` used `urllib.request.urlretrieve` with the default SSL context. On the python.org macOS build of Python (which ships OpenSSL with **no** system CA bundle), this fails with `CERTIFICATE_VERIFY_FAILED`. The download is now streamed through `urllib.request.urlopen` with an explicit context built from `certifi`'s CA bundle (`_create_ssl_context()`), falling back to the platform default if certifi is somehow unavailable. Progress reporting and timeout behavior are preserved.

## 2. `PATENT_MPEP_DEVICE` documented but never read
The env var is referenced in `README.md` and `commands/setup-patent-system.md` (e.g. `PATENT_MPEP_DEVICE=cpu ... setup --rebuild`) but `grep` showed it was read **nowhere** — `FORCE_CPU` was the only working switch. `get_device()` now honors `PATENT_MPEP_DEVICE` (`cpu` / `gpu`|`cuda` / `mps` / `auto`), so the documented commands work. `FORCE_CPU` continues to work unchanged.

## 3. Apple Silicon (MPS) never detected
`get_device()` only checked CUDA, so Apple Silicon silently fell through to CPU. It now detects MPS — but **deliberately stays on CPU by default**, because (per the reporter's benchmark, which we kept) MPS runs the BGE-base embedding workload **~50x slower** than CPU. Users can opt in with `PATENT_MPEP_DEVICE=mps`. The new `"mps"` return value only occurs on explicit opt-in, so default behavior for all existing users is unchanged.

## Tests & docs
- `tests/test_device.py` (7 tests, fake-torch injection) — FORCE_CPU, PATENT_MPEP_DEVICE=cpu/mps, CUDA, MPS-defaults-to-CPU, no-accelerator, old-torch-without-mps.
- `tests/test_downloaders.py` (2 tests) — context verifies certs (`CERT_REQUIRED`, `check_hostname`) and is built from `certifi.where()`.
- `docs/GPU_SETUP.md` — new "macOS / Apple Silicon" section (MPS perf note + SSL troubleshooting).
- `CHANGELOG.md` updated.
- `ruff check` and `black --check` clean on all changed files; 9/9 new tests pass.

Closes #23