### PR TITLE
fix: robust cu126/cu128 routing for unknown GPU capability (#26 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `mps`), which was referenced in docs but never read; `FORCE_CPU` still works (#23)
 - `utils/device`: detect Apple Silicon (MPS) and stay on CPU by default — MPS runs
   the BGE embedding workload ~50x slower; opt in with `PATENT_MPEP_DEVICE=mps` (#23)
+- `hardware_detect`/`auto_setup`: when `nvidia-smi` can't report compute capability
+  (older drivers), select the CUDA wheel by GPU product name so legacy cards still
+  get cu126 without forcing Blackwell onto cu126; add `PATENT_TORCH_CUDA=cu126|cu128`
+  manual override; correct the cu126 Maxwell/Windows kernel-coverage claim (#26 follow-up)
 - `analyzer_base`: WARNING/INFO severity levels now in SEVERITY_ORDER (prevents KeyError)
 - `base_index`: Guard against FAISS returning -1 for unfound results
 - `base_index`: Guard against empty candidates in reranker

--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -201,8 +201,20 @@ kernels for **Turing (sm_75) and newer**:
 
 Pre-Turing cards routed to `cu128` crash at kernel launch with
 `CUDA error: no kernel image is available for execution on the device`. The
-`cu126` build of torch 2.7.1 still bundles `sm_50`–`sm_90`, so those GPUs are
-sent there automatically.
+`cu126` build of torch 2.7.1 ships kernels down to **`sm_61` (Pascal)** on
+Windows — and **`sm_50` (Maxwell)** on Linux — through `sm_90`, so Pascal and
+Volta cards are sent there automatically.
+
+> **Maxwell on Windows:** the Windows `cu126` wheel omits `sm_50`/`sm_52`, so a
+> Maxwell card (GTX 9xx, GTX 745/750) may still report "no kernel image" on
+> Windows. `patent-creator status` will flag the mismatch rather than failing
+> silently. Linux `cu126` wheels do include Maxwell.
+
+**If `nvidia-smi` can't report compute capability** (older drivers predate the
+field), the wheel is chosen from the GPU's product *name* instead: recognized
+pre-Turing cards still get `cu126`, and everything else defaults to `cu128`. You
+can always force the choice with `PATENT_TORCH_CUDA=cu126` or
+`PATENT_TORCH_CUDA=cu128`.
 
 ## Troubleshooting
 
@@ -229,13 +241,17 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
 
 Your PyTorch build has no compiled kernels for your GPU's architecture —
 typically a pre-Turing card (GTX 10-series and older, compute capability < 7.5)
-that received a `cu128` build. Reinstall the `cu126` build, which includes
-`sm_50`–`sm_90`:
+that received a `cu128` build. Reinstall the `cu126` build (kernels `sm_61`–`sm_90`
+on Windows, `sm_50`–`sm_90` on Linux):
 
 ```powershell
 pip uninstall -y torch torchvision
 pip install torch==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu126
 ```
+
+Or set `PATENT_TORCH_CUDA=cu126` before `patent-creator setup` to force the
+legacy wheel — handy when auto-detection can't read your GPU's compute
+capability.
 
 Confirm your GPU's architecture is now supported:
 

--- a/mcp_server/hardware_detect.py
+++ b/mcp_server/hardware_detect.py
@@ -80,10 +80,12 @@ def get_nvidia_gpu_names():
 # intentionally NOT matched, so modern cards keep the cu128 wheel.
 _LEGACY_NVIDIA_PATTERNS = (
     r"gtx\s*7(45|50)",  # Maxwell GTX 745 / 750 / 750 Ti
-    r"gtx\s*9\d0",  # Maxwell GTX 950 / 960 / 970 / 980 (Ti)
+    r"gtx\s*8\d0",  # Maxwell GTX 8xxM mobile (840M / 850M / 860M / 870M / 880M)
+    r"gtx\s*9\d{2}",  # Maxwell GTX 9-series incl. mobile (950 / 970 / 960M / 965M)
     r"gtx\s*10[1-8]0",  # Pascal GTX 1050 / 1060 / 1070 / 1080 (Ti)
     r"\bgt\s*10[0-3]0",  # Pascal GT 1010 / 1030
-    r"\bmx[1-3]\d0\b",  # Pascal MX150 / MX250 / MX350
+    r"\bmx[1-3]\d0\b",  # Pascal MX150 / MX250 / MX350 (MX450+ is Turing — excluded)
+    r"\b9[0-6]0mx?\b",  # Maxwell/Pascal mobile reported without GTX (940M / 940MX)
     r"titan\s*xp\b",  # Pascal Titan Xp
     r"titan\s*x\b",  # Maxwell / Pascal Titan X
     r"titan\s*v\b",  # Volta Titan V

--- a/mcp_server/hardware_detect.py
+++ b/mcp_server/hardware_detect.py
@@ -5,6 +5,7 @@ Detects GPU type and determines correct PyTorch version
 """
 
 import contextlib
+import os
 import platform
 import re
 import subprocess
@@ -23,12 +24,13 @@ def get_nvidia_compute_capability():
     """Return the LOWEST NVIDIA GPU compute capability as a float, or None.
 
     nvidia-smi reports one compute_cap per GPU. We return the minimum so the
-    oldest card in the system drives wheel selection: cu126 covers sm_50-sm_90,
-    so if any GPU is pre-Turing the whole system must use cu126. Non-numeric
-    lines (warnings, headers) are skipped rather than failing detection.
+    oldest card in the system drives wheel selection: any pre-Turing GPU forces
+    the whole system onto cu126. Non-numeric lines (warnings, headers) are
+    skipped rather than failing detection.
 
     e.g. GTX 1080 (Pascal) -> 6.1, RTX 3090 (Ampere) -> 8.6, RTX 5090 -> 12.0;
-    a mixed 6.1 + 8.6 system -> 6.1.
+    a mixed 6.1 + 8.6 system -> 6.1. Returns None when nvidia-smi is missing,
+    fails, or predates the compute_cap query field (older drivers).
     """
     try:
         result = subprocess.run(
@@ -49,6 +51,53 @@ def get_nvidia_compute_capability():
     except (subprocess.TimeoutExpired, OSError):
         pass
     return None
+
+
+def get_nvidia_gpu_names():
+    """Return NVIDIA GPU product names from nvidia-smi (empty list on failure).
+
+    Unlike compute_cap, the product name is reported even by older nvidia-smi
+    builds that predate the compute_cap field, so it can drive wheel selection
+    when the numeric compute capability is unavailable.
+    """
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return []
+
+
+# Pre-Turing (compute capability < 7.5) NVIDIA product-name patterns: Maxwell,
+# Pascal, and Volta. Used only as a fallback when nvidia-smi can't report the
+# numeric compute capability. Turing+ names (RTX, GTX 16xx, Tesla T4) are
+# intentionally NOT matched, so modern cards keep the cu128 wheel.
+_LEGACY_NVIDIA_PATTERNS = (
+    r"gtx\s*7(45|50)",  # Maxwell GTX 745 / 750 / 750 Ti
+    r"gtx\s*9\d0",  # Maxwell GTX 950 / 960 / 970 / 980 (Ti)
+    r"gtx\s*10[1-8]0",  # Pascal GTX 1050 / 1060 / 1070 / 1080 (Ti)
+    r"\bgt\s*10[0-3]0",  # Pascal GT 1010 / 1030
+    r"\bmx[1-3]\d0\b",  # Pascal MX150 / MX250 / MX350
+    r"titan\s*xp\b",  # Pascal Titan Xp
+    r"titan\s*x\b",  # Maxwell / Pascal Titan X
+    r"titan\s*v\b",  # Volta Titan V
+    r"\bv100\b",  # Volta Tesla V100
+    r"\bgv100\b",  # Volta Quadro GV100
+    r"tesla\s*[mp]\d",  # Tesla M-series (Maxwell) / P-series (Pascal)
+    r"quadro\s*[mp]\d{3,}",  # Quadro M / P workstation cards
+)
+
+
+def is_legacy_nvidia_name(name):
+    """True if an NVIDIA product name is a pre-Turing (compute < 7.5) card."""
+    lowered = name.lower()
+    return any(re.search(pattern, lowered) for pattern in _LEGACY_NVIDIA_PATTERNS)
 
 
 def detect_apple_silicon():
@@ -75,22 +124,71 @@ def get_pytorch_install_command():
     has_apple_silicon = detect_apple_silicon()
 
     if has_nvidia:
-        compute_cap = get_nvidia_compute_capability()
-        # cu128 wheels only ship compiled kernels for sm_75+ (Turing and newer).
-        # Pre-Turing cards (Pascal sm_61, Volta sm_70, Maxwell sm_5x) get a
-        # "no kernel image is available for execution on the device" error with
-        # cu128. The cu126 build of torch 2.7.1 still bundles sm_50..sm_90, so
-        # route older GPUs there. Unknown capability falls through to cu128.
-        if compute_cap is not None and compute_cap < 7.5:
+        cu126 = "https://download.pytorch.org/whl/cu126"
+        cu128 = "https://download.pytorch.org/whl/cu128"
+
+        # Explicit manual override, useful when auto-detection can't determine the
+        # GPU architecture (see the unknown-capability path below) or a user wants
+        # to pin a specific build.
+        override = os.environ.get("PATENT_TORCH_CUDA", "").strip().lower()
+        if override == "cu126":
             return (
                 "torch==2.7.1 torchvision==0.22.1",
-                "https://download.pytorch.org/whl/cu126",
-                f"[GPU] NVIDIA GPU (compute {compute_cap}) detected - installing "
+                cu126,
+                "[GPU] NVIDIA GPU detected - installing PyTorch 2.7.1 / CUDA 12.6 "
+                "(forced via PATENT_TORCH_CUDA=cu126)",
+            )
+        if override == "cu128":
+            return (
+                "torch>=2.0.0",
+                cu128,
+                "[GPU] NVIDIA GPU detected - installing PyTorch / CUDA 12.8 "
+                "(forced via PATENT_TORCH_CUDA=cu128)",
+            )
+
+        # cu128 wheels only ship compiled kernels for sm_75+ (Turing and newer).
+        # Pre-Turing cards (Pascal sm_61, Volta sm_70, Maxwell sm_5x) hit a
+        # "no kernel image is available for execution on the device" error with
+        # cu128, so they need the cu126 build of torch 2.7.1 (kernels down to
+        # sm_61 on Windows / sm_50 on Linux, through sm_90).
+        compute_cap = get_nvidia_compute_capability()
+        cu126_reason = None
+        if compute_cap is not None:
+            if compute_cap < 7.5:
+                cu126_reason = f"compute {compute_cap}"
+        else:
+            # nvidia-smi couldn't report compute_cap (e.g. an older driver whose
+            # nvidia-smi predates the field). Defaulting blindly to cu128 would
+            # re-break legacy cards, but defaulting to cu126 would break Blackwell
+            # (sm_120, absent from the cu126 wheel). nvidia-smi still reports the
+            # product *name* on those drivers, so route known pre-Turing cards by
+            # name; everything else stays on cu128.
+            legacy = [n for n in get_nvidia_gpu_names() if is_legacy_nvidia_name(n)]
+            if legacy:
+                cu126_reason = f"legacy GPU {legacy[0]!r}, compute capability unavailable"
+
+        if cu126_reason is not None:
+            return (
+                "torch==2.7.1 torchvision==0.22.1",
+                cu126,
+                f"[GPU] NVIDIA GPU ({cu126_reason}) detected - installing "
                 "PyTorch 2.7.1 with CUDA 12.6 (legacy GPU architecture support)",
+            )
+        if compute_cap is None:
+            # Unknown capability and no recognized legacy name: default to cu128
+            # (correct for all current/modern GPUs) but tell the user how to
+            # recover if they actually have an unrecognized pre-Turing card.
+            return (
+                "torch>=2.0.0",
+                cu128,
+                "[GPU] NVIDIA GPU detected but compute capability could not be "
+                "determined - installing CUDA 12.8 (cu128). If you have a "
+                "pre-Turing GPU and see 'no kernel image is available', set "
+                "PATENT_TORCH_CUDA=cu126.",
             )
         return (
             "torch>=2.0.0",
-            "https://download.pytorch.org/whl/cu128",
+            cu128,
             "[GPU] NVIDIA GPU detected - installing PyTorch with CUDA 12.8 support",
         )
     elif has_apple_silicon:

--- a/scripts/auto_setup.py
+++ b/scripts/auto_setup.py
@@ -5,6 +5,7 @@ Detects hardware and installs the correct PyTorch version automatically
 """
 
 import contextlib
+import os
 import platform
 import subprocess
 import sys
@@ -46,8 +47,8 @@ def get_compute_capability():
         if result.returncode == 0:
             # nvidia-smi emits one compute_cap per GPU; parse each line and
             # return the MINIMUM so the oldest GPU in the system drives wheel
-            # selection (cu126 covers sm_50-sm_90). Non-numeric lines (warnings,
-            # headers) are skipped rather than failing the whole detection.
+            # selection (any pre-Turing card forces cu126). Non-numeric lines
+            # (warnings, headers) are skipped rather than failing detection.
             caps = []
             for line in result.stdout.splitlines():
                 cleaned = line.strip()
@@ -72,22 +73,46 @@ def install_pytorch(gpu_available=False, compute_cap=None):
         return run_command(cmd, "Installing PyTorch (CPU)")
 
     # cu128 wheels only ship kernels for sm_75+ (Turing and newer). Pre-Turing
-    # GPUs (Pascal sm_61, Volta sm_70, Maxwell sm_5x) crash at kernel launch
-    # with "no kernel image is available for execution on the device". For those
-    # we pin the cu126 build of torch 2.7.1, which still bundles sm_50..sm_90.
-    if compute_cap is not None and compute_cap < 7.5:
+    # GPUs (Pascal sm_61, Volta sm_70, Maxwell sm_5x) crash at kernel launch with
+    # "no kernel image is available for execution on the device", so they need
+    # the cu126 build of torch 2.7.1 (kernels down to sm_61 on Windows / sm_50 on
+    # Linux, through sm_90).
+    override = os.environ.get("PATENT_TORCH_CUDA", "").strip().lower()
+    if override == "cu126":
+        route_cu126, reason = True, "forced via PATENT_TORCH_CUDA=cu126"
+    elif override == "cu128":
+        route_cu126, reason = False, "forced via PATENT_TORCH_CUDA=cu128"
+    elif compute_cap is not None:
+        route_cu126 = compute_cap < 7.5
+        reason = f"Compute {compute_cap}"
+    else:
+        # Unknown capability (older driver without the compute_cap field): route
+        # known pre-Turing cards by product name via the shared detector, so a
+        # legacy GPU isn't sent to cu128 while Blackwell isn't sent to cu126.
+        reason = "compute capability unavailable"
+        try:
+            from mcp_server.hardware_detect import (
+                get_nvidia_gpu_names,
+                is_legacy_nvidia_name,
+            )
+
+            route_cu126 = any(is_legacy_nvidia_name(n) for n in get_nvidia_gpu_names())
+        except Exception:
+            route_cu126 = False
+
+    if route_cu126:
         torch_spec = "torch==2.7.1 torchvision==0.22.1"
         cuda_pkg = "cu126"
         cuda_name = "12.6"
         print("\n" + "=" * 60)
-        print(f"Legacy NVIDIA GPU detected (Compute {compute_cap}) - Installing CUDA {cuda_name}")
+        print(f"Legacy NVIDIA GPU detected ({reason}) - Installing CUDA {cuda_name}")
         print("=" * 60)
     else:
         torch_spec = "torch torchvision"
         cuda_pkg = "cu128"  # Turing and newer
         cuda_name = "12.8"
         print("\n" + "=" * 60)
-        print(f"NVIDIA GPU detected - Installing CUDA {cuda_name} version")
+        print(f"NVIDIA GPU detected ({reason}) - Installing CUDA {cuda_name} version")
         print("=" * 60)
 
     # Uninstall any existing PyTorch first. Quote sys.executable so a venv path

--- a/tests/test_hardware_detect.py
+++ b/tests/test_hardware_detect.py
@@ -17,18 +17,30 @@ LEGACY_NAMES = [
     "Quadro P2000",
     "Tesla P100-PCIE-16GB",
     "NVIDIA GeForce MX150",
+    # Maxwell mobile parts (common in laptops, frequently paired with old
+    # drivers that can't report compute_cap — exactly the fallback path).
+    "NVIDIA GeForce GTX 965M",
+    "NVIDIA GeForce GTX 960M",
+    "NVIDIA GeForce GTX 860M",
+    "NVIDIA GeForce GTX 850M",
+    "NVIDIA GeForce 940MX",
+    "NVIDIA GeForce 940M",
 ]
 
 MODERN_NAMES = [
     "NVIDIA GeForce RTX 5090",
     "NVIDIA GeForce RTX 4090",
+    "NVIDIA GeForce RTX 4060 Laptop GPU",  # 'x060' must not trip the 9x0M pattern
     "NVIDIA GeForce RTX 3090",
+    "NVIDIA GeForce RTX 3090 Ti",
     "NVIDIA GeForce RTX 2080 Ti",
     "NVIDIA GeForce GTX 1660 Ti",  # Turing sm_75 — must NOT be treated as legacy
     "NVIDIA GeForce GTX 1650",  # Turing sm_75
+    "NVIDIA GeForce MX450",  # Turing — newer than the Pascal MX1/2/3xx
     "Tesla T4",
     "NVIDIA A100-SXM4-40GB",
     "NVIDIA H100 PCIe",
+    "NVIDIA L4",
     "Quadro RTX 4000",
     "NVIDIA RTX A6000",
 ]

--- a/tests/test_hardware_detect.py
+++ b/tests/test_hardware_detect.py
@@ -1,0 +1,112 @@
+"""Tests for GPU wheel selection (mcp_server.hardware_detect)."""
+
+import pytest
+
+import mcp_server.hardware_detect as hw
+from mcp_server.hardware_detect import get_pytorch_install_command, is_legacy_nvidia_name
+
+LEGACY_NAMES = [
+    "NVIDIA GeForce GTX 1080 Ti",
+    "NVIDIA GeForce GTX 1060 6GB",
+    "NVIDIA GeForce GTX 970",
+    "NVIDIA GeForce GTX 750 Ti",
+    "NVIDIA TITAN Xp",
+    "NVIDIA TITAN X (Pascal)",
+    "NVIDIA TITAN V",
+    "Tesla V100-SXM2-16GB",
+    "Quadro P2000",
+    "Tesla P100-PCIE-16GB",
+    "NVIDIA GeForce MX150",
+]
+
+MODERN_NAMES = [
+    "NVIDIA GeForce RTX 5090",
+    "NVIDIA GeForce RTX 4090",
+    "NVIDIA GeForce RTX 3090",
+    "NVIDIA GeForce RTX 2080 Ti",
+    "NVIDIA GeForce GTX 1660 Ti",  # Turing sm_75 — must NOT be treated as legacy
+    "NVIDIA GeForce GTX 1650",  # Turing sm_75
+    "Tesla T4",
+    "NVIDIA A100-SXM4-40GB",
+    "NVIDIA H100 PCIe",
+    "Quadro RTX 4000",
+    "NVIDIA RTX A6000",
+]
+
+
+@pytest.mark.parametrize("name", LEGACY_NAMES)
+def test_legacy_names_detected(name):
+    assert is_legacy_nvidia_name(name) is True
+
+
+@pytest.mark.parametrize("name", MODERN_NAMES)
+def test_modern_names_not_legacy(name):
+    assert is_legacy_nvidia_name(name) is False
+
+
+@pytest.fixture(autouse=True)
+def _force_nvidia(monkeypatch):
+    """Pretend an NVIDIA GPU is present and clear the override env var."""
+    monkeypatch.setattr(hw, "detect_nvidia_gpu", lambda: True)
+    monkeypatch.setattr(hw, "detect_apple_silicon", lambda: False)
+    monkeypatch.delenv("PATENT_TORCH_CUDA", raising=False)
+
+
+def _set(monkeypatch, *, cap=None, names=()):
+    monkeypatch.setattr(hw, "get_nvidia_compute_capability", lambda: cap)
+    monkeypatch.setattr(hw, "get_nvidia_gpu_names", lambda: list(names))
+
+
+def test_modern_capability_routes_cu128(monkeypatch):
+    _set(monkeypatch, cap=12.0)
+    _, url, _ = get_pytorch_install_command()
+    assert "cu128" in url
+
+
+def test_pre_turing_capability_routes_cu126(monkeypatch):
+    _set(monkeypatch, cap=6.1)
+    spec, url, _ = get_pytorch_install_command()
+    assert "cu126" in url
+    assert "2.7.1" in spec
+
+
+def test_volta_capability_routes_cu126(monkeypatch):
+    """Volta (7.0) is < 7.5 and absent from cu128 — it must go to cu126."""
+    _set(monkeypatch, cap=7.0)
+    _, url, _ = get_pytorch_install_command()
+    assert "cu126" in url
+
+
+def test_unknown_capability_legacy_name_routes_cu126(monkeypatch):
+    _set(monkeypatch, cap=None, names=["NVIDIA GeForce GTX 1080"])
+    _, url, desc = get_pytorch_install_command()
+    assert "cu126" in url
+    assert "GTX 1080" in desc
+
+
+def test_unknown_capability_modern_name_routes_cu128(monkeypatch):
+    """Unknown capability + a Blackwell name must NOT be forced onto cu126."""
+    _set(monkeypatch, cap=None, names=["NVIDIA GeForce RTX 5090"])
+    _, url, desc = get_pytorch_install_command()
+    assert "cu128" in url
+    assert "could not be determined" in desc
+
+
+def test_unknown_capability_no_names_routes_cu128(monkeypatch):
+    _set(monkeypatch, cap=None, names=[])
+    _, url, _ = get_pytorch_install_command()
+    assert "cu128" in url
+
+
+def test_env_override_cu126_beats_modern_card(monkeypatch):
+    monkeypatch.setenv("PATENT_TORCH_CUDA", "cu126")
+    _set(monkeypatch, cap=12.0)
+    _, url, _ = get_pytorch_install_command()
+    assert "cu126" in url
+
+
+def test_env_override_cu128_beats_legacy_card(monkeypatch):
+    monkeypatch.setenv("PATENT_TORCH_CUDA", "cu128")
+    _set(monkeypatch, cap=6.1)
+    _, url, _ = get_pytorch_install_command()
+    assert "cu128" in url


### PR DESCRIPTION
Resolves the two follow-ups tracked in #29 from the review of #26.

## 1. Unknown-capability routing no longer re-breaks legacy cards (or Blackwell)
#26 fell back to **cu128** when `nvidia-smi` can't report compute capability — but that's exactly the wheel that crashes pre-Turing cards, and the "unknown" case correlates strongly with the *older drivers* those cards run. The obvious fix (default unknown → cu126) is **also wrong**: cu126 ships no `sm_120` kernels, so it would crash **Blackwell** (RTX 50-series).

Resolution: `nvidia-smi` still reports the GPU **product name** even on drivers too old for the `compute_cap` field, so we route by name when capability is unknown:
- `get_nvidia_gpu_names()` — names via `--query-gpu=name` (works on old drivers).
- `is_legacy_nvidia_name()` — conservative pattern set for Maxwell/Pascal/Volta. Turing `GTX 16xx`, all `RTX`, and `Tesla T4` are **explicitly not matched**, so modern cards keep cu128.
- Known legacy name + unknown capability → cu126; anything else → cu128 with a message explaining how to recover.

The arch-list check added in #26 remains the backstop for any misroute.

## 2. `PATENT_TORCH_CUDA=cu126|cu128` manual override
A reliable escape hatch for any case auto-detection can't resolve. Highest priority in the routing.

## 3. Corrected the cu126 kernel-coverage claim
Comments/docs said cu126 "bundles sm_50–sm_90." True on Linux, but the **Windows** cu126 wheel starts at `sm_61` (no Maxwell `sm_50/52`). Updated `hardware_detect.py`, `auto_setup.py`, and `docs/GPU_SETUP.md` with the Windows caveat (a Maxwell-on-Windows user gets a flagged mismatch from the arch-list check, not a silent crash).

## Parity & tests
- `scripts/auto_setup.py` mirrors the same override + name-fallback (shared via import).
- `tests/test_hardware_detect.py` — **30 cases**: the name matcher across 22 real GPU names (11 legacy / 11 modern incl. GTX 1660 Ti, RTX 5090, A100, T4), plus 8 routing scenarios (override both ways, compute < 7.5, Volta 7.0, unknown+legacy-name, unknown+Blackwell-name, unknown+no-name).
- `ruff check` and `black --check` clean; 30/30 pass.

Closes #29