### PR TITLE
ci: allow manual runs via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` so CI can be run on demand from the Actions tab. Opening this PR is also the first real exercise of the CI pipeline now that Actions is enabled — watching it go green validates the gate end-to-end.