### PR TITLE
fix: correct silent search/claims defects that return wrong results

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -285,7 +285,7 @@ class BigQueryPatentSearch:
             country_code
         FROM `{self.FULL_TABLE_ID}`
         WHERE {where_clause}
-        ORDER BY publication_date DESC
+        ORDER BY publication_date DESC, publication_number DESC
         LIMIT @limit
         OFFSET @offset
         """
@@ -496,12 +496,14 @@ class BigQueryPatentSearch:
             CAST(publication_date AS STRING) AS publication_date,
             application_number,
             country_code
-        FROM `{self.FULL_TABLE_ID}`,
-        UNNEST(cpc) AS cpc_entry
+        FROM `{self.FULL_TABLE_ID}`
         WHERE
             country_code = @country
-            AND STARTS_WITH(cpc_entry.code, @cpc_code)
-        ORDER BY publication_date DESC
+            AND EXISTS (
+                SELECT 1 FROM UNNEST(cpc) AS cpc_entry
+                WHERE STARTS_WITH(cpc_entry.code, @cpc_code)
+            )
+        ORDER BY publication_date DESC, publication_number DESC
         LIMIT @limit
         """
 
@@ -599,12 +601,14 @@ class BigQueryPatentSearch:
             CAST(publication_date AS STRING) AS publication_date,
             application_number,
             country_code
-        FROM `{self.FULL_TABLE_ID}`,
-        UNNEST(ipc) AS ipc_entry
+        FROM `{self.FULL_TABLE_ID}`
         WHERE
             country_code = @country
-            AND STARTS_WITH(ipc_entry.code, @ipc_code)
-        ORDER BY publication_date DESC
+            AND EXISTS (
+                SELECT 1 FROM UNNEST(ipc) AS ipc_entry
+                WHERE STARTS_WITH(ipc_entry.code, @ipc_code)
+            )
+        ORDER BY publication_date DESC, publication_number DESC
         LIMIT @limit
         """
 

--- a/mcp_server/claims_analyzer.py
+++ b/mcp_server/claims_analyzer.py
@@ -132,14 +132,17 @@ class ClaimsAnalyzer(BaseAnalyzer):
             claim = {
                 "number": int(claim_num),
                 "text": claim_body.strip(),
-                "is_independent": not bool(re.search(r"claim \d+", claim_body, re.IGNORECASE)),
+                # Plural "claims 1 to 5" / "claims 1 and 2" are the standard way
+                # to write multiple-dependent claims; the old `claim \d+` pattern
+                # missed them, mislabeling those dependent claims as independent.
+                "is_independent": not bool(re.search(r"\bclaims?\s+\d+", claim_body, re.IGNORECASE)),
                 "depends_on": None,
                 "elements": {},
                 "limitations": [],
             }
 
             # Check for dependency
-            dep_match = re.search(r"claim (\d+)", claim_body, re.IGNORECASE)
+            dep_match = re.search(r"\bclaims?\s+(\d+)", claim_body, re.IGNORECASE)
             if dep_match:
                 dep_num = int(dep_match.group(1))
                 if dep_num != int(claim_num):  # Prevent self-referencing

--- a/mcp_server/epo_api.py
+++ b/mcp_server/epo_api.py
@@ -670,7 +670,8 @@ class EPOClient:
                 "epo_get_patent_completed",
                 extra={
                     "patent_number": patent_number,
-                    "title": result.get("title", "")[:50],
+                    # title may be None (no English-language title); guard the slice
+                    "title": (result.get("title") or "")[:50],
                 },
             )
 

--- a/mcp_server/epo_claims_analyzer.py
+++ b/mcp_server/epo_claims_analyzer.py
@@ -141,14 +141,17 @@ class EPOClaimsAnalyzer(BaseAnalyzer):
             claim = {
                 "number": int(claim_num),
                 "text": claim_body.strip(),
-                "is_independent": not bool(re.search(r"claim \d+", claim_body, re.IGNORECASE)),
+                # Match plural "claims 1 to 5" too — the EPO multiple-dependent
+                # form — which `claim \d+` missed, mislabeling dependent claims
+                # as independent and triggering false Rule 43(2) issues.
+                "is_independent": not bool(re.search(r"\bclaims?\s+\d+", claim_body, re.IGNORECASE)),
                 "depends_on": None,
                 "category": self._determine_claim_category(claim_body),
                 "limitations": [],
             }
 
             # Check for dependency
-            dep_match = re.search(r"claim (\d+)", claim_body, re.IGNORECASE)
+            dep_match = re.search(r"\bclaims?\s+(\d+)", claim_body, re.IGNORECASE)
             if dep_match:
                 dep_num = int(dep_match.group(1))
                 if dep_num != int(claim_num):

--- a/mcp_server/pct_formalities_checker.py
+++ b/mcp_server/pct_formalities_checker.py
@@ -453,7 +453,10 @@ class PCTFormalitiesChecker(BaseAnalyzer):
             )
             if claim_match:
                 claim_text = claim_match.group(1)
-                if not re.search(r"claim \d+", claim_text, re.IGNORECASE):
+                # Also recognize plural "claims 1 to 5" dependency references, so a
+                # set where every claim is dependent (some via the plural form) is
+                # not mistaken for having an independent claim.
+                if not re.search(r"\bclaims?\s+\d+", claim_text, re.IGNORECASE):
                     has_independent = True
                     break
 

--- a/mcp_server/tools/patent_law_tools.py
+++ b/mcp_server/tools/patent_law_tools.py
@@ -107,8 +107,10 @@ def register_patent_law_tools(
                         # Source may not be indexed yet — skip silently
                         pass
 
-                # Sort by score and limit
-                all_results.sort(key=lambda x: x.get("score", 0), reverse=True)
+                # Sort by relevance and limit. mpep_index.search() returns the
+                # rerank score under "relevance_score" — keying on "score" made
+                # this a silent no-op that dropped the best cross-source passages.
+                all_results.sort(key=lambda x: x.get("relevance_score", 0), reverse=True)
                 all_results = all_results[:top_k]
             else:
                 # Search all sources (no filter)

--- a/mcp_server/uspto_api.py
+++ b/mcp_server/uspto_api.py
@@ -451,9 +451,12 @@ class USPTOClient:
                 }
             )
 
-        # Add year range filter
+        # Add year range filter. start_year/end_year are documented as the
+        # *filing* year (see validation.PatentSearchInput); filtering on grantDate
+        # returned the wrong patents and silently excluded every pending /
+        # published-but-ungranted application.
         if start_year or end_year:
-            range_filter: dict[str, Any] = {"field": "applicationMetaData.grantDate"}
+            range_filter: dict[str, Any] = {"field": "applicationMetaData.filingDate"}
             if start_year:
                 range_filter["valueFrom"] = f"{start_year}-01-01"
             else:
@@ -535,19 +538,25 @@ class USPTOClient:
         """
         app_meta = data.get("applicationMetaData", {})
 
-        # Extract inventors
+        # Extract inventors. The ODP API usually returns a list, but a single
+        # entry can arrive as a bare dict; coerce so iteration never walks dict
+        # keys and raises AttributeError (mirrors the EPO parser's handling).
         inventors = []
         inventor_bag = app_meta.get("inventorBag", [])
+        if isinstance(inventor_bag, dict):
+            inventor_bag = [inventor_bag]
         for inv in inventor_bag:
-            name = inv.get("inventorNameText", "")
+            name = inv.get("inventorNameText", "") if isinstance(inv, dict) else ""
             if name:
                 inventors.append(name)
 
         # Extract applicants
         applicants = []
         applicant_bag = app_meta.get("applicantBag", [])
+        if isinstance(applicant_bag, dict):
+            applicant_bag = [applicant_bag]
         for app in applicant_bag:
-            name = app.get("applicantNameText", "")
+            name = app.get("applicantNameText", "") if isinstance(app, dict) else ""
             if name:
                 applicants.append(name)
 

--- a/tests/test_claim_reference_parsing.py
+++ b/tests/test_claim_reference_parsing.py
@@ -1,0 +1,73 @@
+"""Regression tests for plural claim-reference parsing.
+
+Dependent claims are routinely written in the plural — "claims 1 to 5",
+"claims 1 and 2" (the standard multiple-dependent form, especially at the
+EPO/PCT). The original ``claim \\d+`` pattern only matched the singular
+"claim N", so those dependent claims were mislabeled as independent. That
+produced wrong independent/dependent counts, false EPO Rule 43(2) issues,
+and — in the PCT checker — masked genuine "no independent claim" defects.
+"""
+
+from mcp_server.claims_analyzer import ClaimsAnalyzer
+from mcp_server.epo_claims_analyzer import EPOClaimsAnalyzer
+from mcp_server.pct_formalities_checker import PCTFormalitiesChecker
+
+
+class TestPluralDependencyUS:
+    def test_plural_reference_is_dependent(self):
+        text = (
+            "1. A widget comprising a frame and a wheel.\n"
+            "2. The widget of claim 1, wherein the wheel is round.\n"
+            "3. A widget according to claims 1 to 2, further comprising a brake.\n"
+            "4. The widget of any one of claims 1 and 3, wherein the brake is hydraulic."
+        )
+        claims = {c["number"]: c for c in ClaimsAnalyzer()._parse_claims(text)}
+
+        assert claims[1]["is_independent"] is True
+        # Singular and both plural forms must register as dependent.
+        assert claims[2]["is_independent"] is False and claims[2]["depends_on"] == 1
+        assert claims[3]["is_independent"] is False and claims[3]["depends_on"] == 1
+        assert claims[4]["is_independent"] is False and claims[4]["depends_on"] == 1
+
+    def test_independent_claim_without_reference_stays_independent(self):
+        text = "1. A method comprising receiving data and processing the data."
+        claims = ClaimsAnalyzer()._parse_claims(text)
+        assert claims[0]["is_independent"] is True
+        assert claims[0]["depends_on"] is None
+
+
+class TestPluralDependencyEPO:
+    def test_plural_reference_is_dependent(self):
+        text = (
+            "1. A device comprising a sensor.\n"
+            "2. Device according to claims 1 to 1, characterized by a display."
+        )
+        claims = EPOClaimsAnalyzer()._parse_claims(text)
+        assert claims[0]["is_independent"] is True
+        assert claims[1]["is_independent"] is False
+        assert claims[1]["depends_on"] == 1
+
+
+class TestPCTIndependentDetection:
+    def test_all_dependent_via_plural_form_is_flagged(self):
+        """A claim set where every claim depends on others — expressed with the
+        plural form — must still raise the 'no independent claim' defect."""
+        spec = (
+            "CLAIMS\n"
+            "1. The method of claims 2 to 3, wherein A occurs.\n"
+            "2. The method of claims 1 and 3, wherein B occurs.\n"
+            "3. The method of claims 1 to 2, wherein C occurs."
+        )
+        checker = PCTFormalitiesChecker()
+        checker._check_claims_format(spec)
+        assert any("independent" in issue.problem.lower() for issue in checker.issues)
+
+    def test_real_independent_claim_not_flagged(self):
+        spec = (
+            "CLAIMS\n"
+            "1. A method, comprising step A.\n"
+            "2. The method of claims 1 to 1, further comprising step B."
+        )
+        checker = PCTFormalitiesChecker()
+        checker._check_claims_format(spec)
+        assert not any("independent" in issue.problem.lower() for issue in checker.issues)

--- a/tests/test_uspto_api.py
+++ b/tests/test_uspto_api.py
@@ -78,3 +78,38 @@ def test_normalize_passes_through_non_search_payloads():
     raw = {"someOtherKey": "value"}
 
     assert USPTOClient._normalize_search_response(raw) is raw
+
+
+def test_year_range_filters_on_filing_date(monkeypatch):
+    """start_year/end_year are documented as the *filing* year, so the range
+    filter must target filingDate — not grantDate, which returned the wrong
+    patents and dropped every ungranted application."""
+    captured = {}
+    client = USPTOClient(api_key="test")
+    monkeypatch.setattr(
+        client, "search_patents", lambda **kw: captured.update(kw) or {"results": [], "totalHits": 0}
+    )
+
+    client.search_patents_simple("robot", start_year=2020, end_year=2023)
+
+    range_filters = captured["range_filters"]
+    assert range_filters[0]["field"] == "applicationMetaData.filingDate"
+    assert range_filters[0]["valueFrom"] == "2020-01-01"
+    assert range_filters[0]["valueTo"] == "2023-12-31"
+
+
+def test_parse_result_coerces_single_inventor_dict():
+    """The ODP API may return a lone inventor/applicant as a bare dict instead
+    of a list; parsing must not walk dict keys and raise AttributeError."""
+    client = USPTOClient(api_key="test")
+    result = client._parse_patent_result(
+        {
+            "applicationMetaData": {
+                "inventorBag": {"inventorNameText": "Ada Lovelace"},
+                "applicantBag": {"applicantNameText": "Analytical Engines Inc"},
+            }
+        }
+    )
+
+    assert result.inventors == ["Ada Lovelace"]
+    assert result.applicants == ["Analytical Engines Inc"]


### PR DESCRIPTION
Seven focused correctness fixes found while auditing the core search & analysis paths. Each silently degrades results today; none is cosmetic. Regression tests added for everything reachable without the ML stack.

## Fixes

### Claims parsing — `claims_analyzer`, `epo_claims_analyzer`, `pct_formalities_checker`
`claim \d+` did **not** match the plural **"claims 1 to 5" / "claims 1 and 2"** form — the standard multiple-dependent phrasing, especially at the EPO/PCT. Those dependent claims were mislabeled **independent**, which:
- corrupts independent/dependent counts,
- raises **false EPO Rule 43(2)** "multiple independent claims" issues,
- **masks genuine PCT "no independent claim" defects** (an all-dependent set written in the plural looked like it had an independent claim).

Now `\bclaims?\s+\d+`.

### BigQuery search — `bigquery_search`
- **CPC/IPC duplicates:** `FROM table, UNNEST(cpc)` with no de-dup emitted one row **per matching code**, so a patent under several `G06F…` codes appeared 2–3× and the duplicates **consumed the `LIMIT`**, silently under-filling results. Rewritten as `EXISTS (… UNNEST …)` → one row per patent.
- **Unstable pagination:** all three paged queries ordered on the non-unique `publication_date` only, so tied rows could swap between pages (skips/dupes on deep paging). Added a `publication_number` tiebreaker.

### USPTO — `uspto_api`
- **Wrong date field:** the year range filtered `grantDate`, but `start_year`/`end_year` are documented as the **filing** year — returning the wrong patents and excluding every pending / published-but-ungranted application. Now `filingDate`.
- **Crash on single inventor:** `inventorBag`/`applicantBag` were assumed to be lists; a lone entry returned as a bare dict crashed the entire parse with `AttributeError`. Now coerced (mirrors the EPO parser).

### EPO — `epo_api`
- `get_patent` crashed with `TypeError` on any patent whose title is `None` (no English-language title — common for DE/FR EP publications): `result.get("title", "")[:50]` → `None[:50]`. Now `(result.get("title") or "")[:50]`.

### Cross-jurisdiction — `patent_law_tools`
- Results were sorted on a non-existent `"score"` key (search returns `"relevance_score"`), making the sort a **no-op** that kept source-iteration order and dropped the best passages. Fixed the key.

## Verification
- `ruff check` clean
- **45 tests pass** (38 existing + 7 new regression tests in `test_claim_reference_parsing.py` and `test_uspto_api.py`)
- BigQuery SQL changes are standard rewrites validated by reading (no live BigQuery credentials locally; exercised by CI)

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi