### PR TITLE
fix: term-based keyword search with relevance ranking for prior art

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -6,6 +6,7 @@ Fast, cloud-based patent search using Google's Patents Public Data
 
 import os
 import platform
+import re
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -192,6 +193,47 @@ class BigQueryPatentSearch:
                 "message": "Could not access patents public data",
             }
 
+    @staticmethod
+    def _tokenize_query(query: str) -> list[str]:
+        """Split a free-text query into search terms for keyword matching.
+
+        Prior-art search lives or dies on recall, so a multi-word query is
+        treated as a set of terms that must each appear in some searched field
+        (AND across terms) rather than as one verbatim phrase. Rules:
+
+        * ``"quoted substrings"`` are kept together as exact phrases.
+        * Standalone boolean operators (and/or/not) and parentheses are dropped,
+          so Boolean-style input degrades gracefully into an all-terms match
+          instead of being matched literally (which found nothing).
+        * Surrounding punctuation is stripped and duplicate terms removed.
+
+        Returns an ordered, de-duplicated list of lowercase terms.
+        """
+        if not query:
+            return []
+
+        lowered = query.lower()
+        phrases = re.findall(r'"([^"]+)"', lowered)
+        remainder = re.sub(r'"[^"]+"', " ", lowered)
+        remainder = re.sub(r"[()]", " ", remainder)
+
+        words = []
+        for word in remainder.split():
+            if word in {"and", "or", "not"}:
+                continue
+            word = word.strip(".,;:'\"-/")
+            if word:
+                words.append(word)
+
+        ordered = [p.strip() for p in phrases if p.strip()] + words
+        seen: set[str] = set()
+        terms: list[str] = []
+        for term in ordered:
+            if term not in seen:
+                seen.add(term)
+                terms.append(term)
+        return terms
+
     def search_by_keywords(
         self,
         query: str,
@@ -240,24 +282,46 @@ class BigQueryPatentSearch:
 
         conditions = ["country_code = @country"]
         parameters = [
-            bigquery.ScalarQueryParameter("query", "STRING", f"%{query.lower()}%"),  # type: ignore[union-attr]
             bigquery.ScalarQueryParameter("country", "STRING", country),  # type: ignore[union-attr]
             bigquery.ScalarQueryParameter("limit", "INT64", limit),  # type: ignore[union-attr]
             bigquery.ScalarQueryParameter("offset", "INT64", offset),  # type: ignore[union-attr]
         ]
 
+        # Map requested fields to (SQL expression, relevance weight). A title hit
+        # is a stronger relevance signal than an abstract/claims hit.
         # claims_localized only carries text for US publications; for EP/WO
         # full-text use epo_api.py.
-        search_conditions = []
-        if "abstract" in search_fields:
-            search_conditions.append("LOWER(abstract_localized[SAFE_OFFSET(0)].text) LIKE @query")
+        field_exprs: list[tuple[str, int]] = []
         if "title" in search_fields:
-            search_conditions.append("LOWER(title_localized[SAFE_OFFSET(0)].text) LIKE @query")
+            field_exprs.append(("LOWER(title_localized[SAFE_OFFSET(0)].text)", 3))
+        if "abstract" in search_fields:
+            field_exprs.append(("LOWER(abstract_localized[SAFE_OFFSET(0)].text)", 1))
         if "claims" in search_fields and country == "US":
-            search_conditions.append("LOWER(claims_localized[SAFE_OFFSET(0)].text) LIKE @query")
+            field_exprs.append(("LOWER(claims_localized[SAFE_OFFSET(0)].text)", 1))
 
-        if search_conditions:
-            conditions.append(f"({' OR '.join(search_conditions)})")
+        # Split the query into terms. Each term must appear in at least one
+        # searched field (AND across terms, OR across fields), so a natural
+        # multi-word query no longer requires one verbatim phrase to match.
+        # Wrap a substring in "double quotes" to force exact-phrase matching.
+        terms = self._tokenize_query(query)
+        if not terms:
+            terms = [query.strip().lower()]  # degenerate input: match as-is
+
+        relevance_parts: list[str] = []
+        if field_exprs:
+            for i, term in enumerate(terms):
+                pname = f"term{i}"
+                parameters.append(
+                    bigquery.ScalarQueryParameter(pname, "STRING", f"%{term}%")  # type: ignore[union-attr]
+                )
+                term_clause = " OR ".join(f"{expr} LIKE @{pname}" for expr, _ in field_exprs)
+                conditions.append(f"({term_clause})")
+                for expr, weight in field_exprs:
+                    relevance_parts.append(
+                        f"CASE WHEN {expr} LIKE @{pname} THEN {weight} ELSE 0 END"
+                    )
+
+        relevance_expr = " + ".join(relevance_parts) if relevance_parts else "0"
 
         if start_year:
             conditions.append("CAST(filing_date AS INT64) >= @start_yyyymmdd")
@@ -282,10 +346,11 @@ class BigQueryPatentSearch:
             CAST(publication_date AS STRING) AS publication_date,
             application_number,
             family_id,
-            country_code
+            country_code,
+            ({relevance_expr}) AS relevance_score
         FROM `{self.FULL_TABLE_ID}`
         WHERE {where_clause}
-        ORDER BY publication_date DESC, publication_number DESC
+        ORDER BY relevance_score DESC, publication_date DESC, publication_number DESC
         LIMIT @limit
         OFFSET @offset
         """
@@ -314,6 +379,7 @@ class BigQueryPatentSearch:
                         "publication_date": self._format_date(row.publication_date),
                         "country": row.country_code,
                         "family_id": row.family_id,
+                        "relevance_score": row.relevance_score,
                     }
                 )
 

--- a/skills/prior-art-search/SKILL.md
+++ b/skills/prior-art-search/SKILL.md
@@ -61,7 +61,17 @@ Implements a professional 7-step prior art search methodology combining:
 2. Synonyms and variations
 3. Technical terminology
 4. Industry-specific terms
-5. Boolean search strings
+5. Synonym sets to run as separate searches
+
+**Query syntax (important):** the keyword search splits a query into terms and
+requires **every term** to appear (AND), each matching the title, abstract, or
+claims (results are ranked by relevance, title hits weighted highest). It does
+**not** parse Boolean operators — `AND`/`OR`/parentheses are ignored. So:
+
+- Use plain space-separated terms for the AND set: `blockchain authentication`.
+- Wrap a phrase in double quotes to require it verbatim: `"distributed ledger"`.
+- For OR / synonyms, run **separate searches** and merge the results — don't put
+  `OR` in one query.
 
 **Output**: Keyword search strategy document
 
@@ -71,10 +81,11 @@ Primary: blockchain authentication
 Synonyms: distributed ledger verification, cryptographic authentication
 Technical: public key infrastructure, digital signature
 Related: decentralized identity, trustless verification
-Searches:
-- "blockchain AND (authentication OR verification)"
-- "(distributed ledger) AND (identity OR credential)"
-- "cryptographic AND (login OR access control)"
+Searches (run each separately, then merge/dedupe):
+- blockchain authentication
+- "distributed ledger" verification
+- cryptographic authentication
+- "public key infrastructure" signature
 ```
 
 ---
@@ -92,14 +103,14 @@ Searches:
 
 **Code**:
 ```python
-from python.bigquery_search import BigQueryPatentSearch
+from mcp_server.bigquery_search import BigQueryPatentSearch
 searcher = BigQueryPatentSearch()
 
-results = searcher.search_patents(
-    query="blockchain authentication",
+results = searcher.search_by_keywords(
+    query="blockchain authentication",  # terms AND-matched, ranked by relevance
     limit=30,
     country="US",
-    start_year=2015  # Look back 5-10 years
+    start_year=2015,  # filing year; look back 5-10 years
 )
 ```
 

--- a/tests/test_keyword_search.py
+++ b/tests/test_keyword_search.py
@@ -1,0 +1,97 @@
+"""Regression tests for keyword prior-art search query construction.
+
+The original search matched the entire query as one substring
+(``LIKE '%multi word query%'``) and ordered by recency, so a normal
+multi-word query required a verbatim phrase (≈8% recall in practice) and
+Boolean-style input matched literally (0 hits). search_by_keywords now
+splits the query into terms (AND across terms, OR across fields) and ranks
+by a relevance score, so these tests pin both the tokenizer and the
+generated SQL without needing live BigQuery.
+"""
+
+from mcp_server.bigquery_search import BigQueryPatentSearch
+
+
+class TestTokenizer:
+    def test_multiword_splits_into_terms(self):
+        assert BigQueryPatentSearch._tokenize_query("blockchain authentication") == [
+            "blockchain",
+            "authentication",
+        ]
+
+    def test_boolean_operators_and_parens_are_dropped(self):
+        # The skill used to recommend this exact form; it must degrade to terms.
+        assert BigQueryPatentSearch._tokenize_query(
+            "blockchain AND (authentication OR verification)"
+        ) == ["blockchain", "authentication", "verification"]
+
+    def test_quoted_phrase_is_preserved(self):
+        assert BigQueryPatentSearch._tokenize_query('"wireless power" implant') == [
+            "wireless power",
+            "implant",
+        ]
+
+    def test_duplicates_removed_and_lowercased(self):
+        assert BigQueryPatentSearch._tokenize_query("Sensor sensor SENSOR") == ["sensor"]
+
+    def test_operator_only_input_is_empty(self):
+        assert BigQueryPatentSearch._tokenize_query("AND OR ()") == []
+
+
+class _FakeQueryJob:
+    def __init__(self):
+        class _Result(list):
+            total_bytes_processed = 0
+            total_bytes_billed = 0
+
+        self._result = _Result()
+
+    def result(self, timeout=None):
+        return self._result
+
+
+class _FakeClient:
+    def __init__(self):
+        self.sql = None
+        self.params = None
+
+    def query(self, sql, job_config=None):
+        self.sql = sql
+        self.params = job_config.query_parameters
+        return _FakeQueryJob()
+
+
+def _run(query, **kwargs):
+    searcher = object.__new__(BigQueryPatentSearch)
+    searcher.client = _FakeClient()
+    searcher.search_by_keywords(query, **kwargs)
+    return searcher.client
+
+
+class TestGeneratedSQL:
+    def test_each_term_becomes_its_own_anded_group(self):
+        client = _run("blockchain authentication", country="US", search_fields=["title", "abstract"])
+        term_params = {p.name: p.value for p in client.params if p.name.startswith("term")}
+        assert term_params == {"term0": "%blockchain%", "term1": "%authentication%"}
+
+        where = client.sql.split("WHERE", 1)[1].split("ORDER BY")[0]
+        # AND across terms, OR across fields within a term.
+        assert "LIKE @term0 OR" in where and "LIKE @term1 OR" in where
+        assert ") AND (" in where
+
+    def test_results_ranked_by_relevance(self):
+        client = _run("wireless sensor", country="US", search_fields=["title"])
+        assert "AS relevance_score" in client.sql
+        assert "ORDER BY relevance_score DESC" in client.sql
+
+    def test_title_weighted_above_abstract_in_score(self):
+        client = _run("sensor", country="US", search_fields=["title", "abstract"])
+        # Title contributes 3, abstract 1, to the relevance score.
+        assert "THEN 3 ELSE 0 END" in client.sql
+        assert "THEN 1 ELSE 0 END" in client.sql
+
+    def test_claims_field_only_used_for_us(self):
+        us = _run("sensor", country="US", search_fields=["claims"])
+        assert "claims_localized" in us.sql
+        ep = _run("sensor", country="EP", search_fields=["claims"])
+        assert "claims_localized" not in ep.sql


### PR DESCRIPTION
## The problem (verified against live BigQuery)

Prior-art keyword search matched the **entire query as one substring** (`LIKE '%multi word query%'`) and ordered by recency. Measured on the live `patents-public-data` set (US, title field):

| Query | Old behavior | Correct intent | Old recall |
|-------|-------------|----------------|-----------|
| `blockchain authentication` | **27** | 326 (both terms) | **~8%** |
| `blockchain AND (authentication OR verification)` *(recommended by the skill itself)* | **0** | 620 | **0%** |

For a prior-art tool — where **recall is the entire point** — that silently dropped 90%+ of relevant art, and *everything* when the documented Boolean syntax was used.

## Fix — `search_by_keywords`

- **Tokenize the query** (`_tokenize_query`): split into terms; keep `"quoted phrases"` verbatim; drop standalone boolean operators / parentheses so Boolean-style input degrades into an all-terms match instead of matching literally. Each term must appear in **some** searched field (AND across terms, OR across fields).
- **Relevance ranking**: add a `relevance_score` (title hit = 3, abstract/claims = 1, summed over terms) and `ORDER BY relevance_score DESC`, then recency. Results are ranked by match quality, not just newest-first. Score is returned per result.
- Updated the prior-art **SKILL.md** to document the real syntax (space-separated terms = AND; quotes = phrase; run synonyms/OR as separate searches) and fixed a stale import/method name in its example.

## Verification
- **109 tests pass** (incl. 9 new tokenizer + SQL-construction tests in `test_keyword_search.py`); ruff clean.
- **End-to-end against live BigQuery**: `implantable wireless charging` now returns on-target, relevance-ranked implant-charging patents (top hits score 12 — all three terms in both title and abstract).

Note for users: an abstract/claims keyword search scans ~200+ GiB, which exceeds the default 25 GiB `PATENT_BIGQUERY_MAX_BYTES_BILLED` cap — so out of the box only title searches run; raise the cap (or search titles) for full-text. Flagging separately; not changed here.

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi