### PR TITLE
feat: central config layer + patent-creator config CLI

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -2,6 +2,20 @@
 
 This guide shows how to set environment variables for API keys on different platforms.
 
+> **Easier: use the built-in config command.** Instead of editing environment
+> variables you can store settings in a config file the server reads:
+>
+> ```bash
+> patent-creator config list                 # every setting, its value, and source
+> patent-creator config set GOOGLE_CLOUD_PROJECT my-project-id
+> patent-creator config set PATENT_BIGQUERY_MAX_BYTES_BILLED 268435456000   # ~250 GiB
+> patent-creator config path                 # where the file lives
+> ```
+>
+> Resolution order is **environment variable > config file > default**, so an
+> explicitly-set environment variable always wins. The settings below can all be
+> managed this way, and `config` works even before the rest of the stack is installed.
+
 ## Windows (PowerShell)
 
 Set permanently for your user account:

--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -22,26 +22,45 @@ if _pkg_dir not in sys.path:
 
 # Import hardware detection for PyTorch installation
 import contextlib
+import io
 
-from hardware_detect import (
-    check_pytorch_installation,
-    get_pytorch_install_command,
-)
+# The server stack (mcp, torch, faiss, ...) is heavy and may be unavailable when
+# the environment isn't set up yet. Guard these imports so lightweight commands
+# such as `config` still run — that is exactly when a user needs to edit settings.
+# Heavy commands are gated centrally in main() when the stack failed to load.
+# stderr is captured during the attempt so a failed import's diagnostics don't
+# leak onto otherwise-clean lightweight commands; real warnings are re-emitted
+# on success.
+_server_import_stderr = io.StringIO()
+try:
+    with contextlib.redirect_stderr(_server_import_stderr):
+        from hardware_detect import (
+            check_pytorch_installation,
+            get_pytorch_install_command,
+        )
+        from server import (
+            INDEX_DIR,
+            MPEP_DIR,
+            MPEP_DOWNLOAD_URL,
+            MPEPIndex,
+            check_all_sources,
+            check_mpep_pdfs,
+            download_35_usc,
+            download_37_cfr,
+            download_mpep_pdfs,
+            download_subsequent_publications,
+            extract_mpep_pdfs,
+        )
 
-# Import from server module
-from server import (
-    INDEX_DIR,
-    MPEP_DIR,
-    MPEP_DOWNLOAD_URL,
-    MPEPIndex,
-    check_all_sources,
-    check_mpep_pdfs,
-    download_35_usc,
-    download_37_cfr,
-    download_mpep_pdfs,
-    download_subsequent_publications,
-    extract_mpep_pdfs,
-)
+    _SERVER_IMPORT_ERROR = None
+    sys.stderr.write(_server_import_stderr.getvalue())
+except (ImportError, SystemExit) as exc:  # SystemExit: server.py exits if mcp is missing
+    _SERVER_IMPORT_ERROR = exc
+    check_pytorch_installation = get_pytorch_install_command = None
+    INDEX_DIR = MPEP_DIR = MPEP_DOWNLOAD_URL = MPEPIndex = None
+    check_all_sources = check_mpep_pdfs = None
+    download_35_usc = download_37_cfr = download_mpep_pdfs = None
+    download_subsequent_publications = extract_mpep_pdfs = None
 
 # Import path utilities for cross-platform path handling
 try:
@@ -626,6 +645,12 @@ def run_server(args):
     server_script = Path(__file__).parent / "server.py"
     cmd = [sys.executable, str(server_script)]
 
+    # Bridge file-backed settings into the environment so the server subprocess
+    # inherits them (an explicitly-set env var still wins). See mcp_server.config.
+    from config import apply_config_to_env
+
+    apply_config_to_env()
+
     env = os.environ.copy()
     if args.no_hyde:
         env["PATENT_MPEP_USE_HYDE"] = "false"
@@ -921,6 +946,103 @@ def download_all_command(args):
         return 1
 
 
+def _format_config_value(opt, value, source):
+    """Render a setting for display, masking secrets."""
+    if opt.is_secret:
+        shown = "(set)" if value else "(not set)"
+    elif value == "":
+        shown = "(empty)"
+    else:
+        shown = value
+    return shown, source
+
+
+def config_list_command(args):
+    """Print all settings, their effective values, and where each comes from."""
+    from config import OPTIONS, config_path, get_effective
+
+    sections: dict = {}
+    for opt in OPTIONS:
+        sections.setdefault(opt.section, []).append(opt)
+
+    print(f"Config file: {config_path()}\n")
+    print("Resolution order: environment variable > config file > default\n")
+    for section, opts in sections.items():
+        print(f"== {section} ==")
+        for opt in opts:
+            value, source = get_effective(opt.key)
+            shown, _ = _format_config_value(opt, value, source)
+            print(f"  {opt.key}")
+            print(f"      = {shown}   [{source}]")
+            print(f"      {opt.description}")
+            if opt.note:
+                print(f"      note: {opt.note}")
+        print()
+    print("Change a setting:  patent-creator config set <KEY> <VALUE>")
+    return 0
+
+
+def config_get_command(args):
+    from config import OPTIONS_BY_KEY, get_effective
+
+    if args.key not in OPTIONS_BY_KEY:
+        print(f"[X] Unknown setting: {args.key}", file=sys.stderr)
+        print("    Run 'patent-creator config list' to see valid keys.", file=sys.stderr)
+        return 1
+    value, source = get_effective(args.key)
+    opt = OPTIONS_BY_KEY[args.key]
+    shown, _ = _format_config_value(opt, value, source)
+    print(f"{shown}   [{source}]")
+    return 0
+
+
+def config_set_command(args):
+    from config import OPTIONS_BY_KEY, normalize, save_value, validate
+
+    if args.key not in OPTIONS_BY_KEY:
+        print(f"[X] Unknown setting: {args.key}", file=sys.stderr)
+        print("    Run 'patent-creator config list' to see valid keys.", file=sys.stderr)
+        return 1
+    error = validate(args.key, args.value)
+    if error:
+        print(f"[X] Invalid value for {args.key}: {error}", file=sys.stderr)
+        return 1
+    value = normalize(args.key, args.value)
+    path = save_value(args.key, value)
+    opt = OPTIONS_BY_KEY[args.key]
+    shown = "(set)" if opt.is_secret else value
+    print(f"[OK] {args.key} = {shown}")
+    print(f"     Saved to {path}")
+    if opt.is_secret:
+        print("     Note: stored in plaintext; protect this file.", file=sys.stderr)
+    if opt.note:
+        print(f"     {opt.note}")
+    return 0
+
+
+def config_unset_command(args):
+    from config import OPTIONS_BY_KEY, unset_value
+
+    if args.key not in OPTIONS_BY_KEY:
+        print(f"[X] Unknown setting: {args.key}", file=sys.stderr)
+        return 1
+    unset_value(args.key)
+    print(f"[OK] {args.key} removed from the config file (default/env now apply).")
+    return 0
+
+
+def config_path_command(args):
+    from config import config_path
+
+    print(config_path())
+    return 0
+
+
+def config_command(args):
+    """Dispatch `config` with no subaction to the listing."""
+    return config_list_command(args)
+
+
 def main():
     """
     Main CLI entry point
@@ -994,12 +1116,49 @@ For more information: https://github.com/RobThePCGuy/Claude-Patent-Creator
     )
     verify_parser.set_defaults(func=verify_config_command)
 
+    # Config command (view/edit settings)
+    config_parser = subparsers.add_parser(
+        "config", help="View or change settings (API keys, BigQuery cap, device, ...)"
+    )
+    config_parser.set_defaults(func=config_command)
+    config_sub = config_parser.add_subparsers(dest="config_action")
+    config_sub.add_parser("list", help="List all settings and their values").set_defaults(
+        func=config_list_command
+    )
+    cfg_get = config_sub.add_parser("get", help="Print one setting's value")
+    cfg_get.add_argument("key")
+    cfg_get.set_defaults(func=config_get_command)
+    cfg_set = config_sub.add_parser("set", help="Set a setting in the config file")
+    cfg_set.add_argument("key")
+    cfg_set.add_argument("value")
+    cfg_set.set_defaults(func=config_set_command)
+    cfg_unset = config_sub.add_parser("unset", help="Remove a setting from the config file")
+    cfg_unset.add_argument("key")
+    cfg_unset.set_defaults(func=config_unset_command)
+    config_sub.add_parser("path", help="Print the config file path").set_defaults(
+        func=config_path_command
+    )
+
     # Download patents command
     args = parser.parse_args()
 
     if not args.command:
         parser.print_help()
         return 0
+
+    # `config` is intentionally usable without the heavy server stack, so users
+    # can set credentials/options before everything else is installed.
+    if args.command != "config" and _SERVER_IMPORT_ERROR is not None:
+        print(
+            f"[X] Could not load required dependencies: {_SERVER_IMPORT_ERROR}",
+            file=sys.stderr,
+        )
+        print(
+            "    Install them with 'pip install \".[dev]\"' and retry. "
+            "('patent-creator config' works without them.)",
+            file=sys.stderr,
+        )
+        return 1
 
     # Run the selected command
     return args.func(args)

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -1,0 +1,264 @@
+"""Central configuration schema and file-backed store.
+
+Every user-tunable setting is declared once in ``OPTIONS`` below. Values resolve
+in priority order:
+
+    real environment variable  >  config file  >  built-in default
+
+The config file (``config.json`` in the platform config dir) lets non-technical
+users — and the CLI / GUI built on this schema — persist settings without
+editing OS environment variables. An explicitly-set environment variable always
+wins, so existing setups and MCP-client ``env`` blocks are never overridden.
+
+The rest of the codebase keeps reading ``os.environ`` as before; ``apply_config_
+to_env()`` (called at server startup) bridges the file into the environment for
+any key the environment does not already set.
+"""
+
+import contextlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+APP_DIR_NAME = "claude-patent-creator"
+GIB = 1024**3
+
+
+@dataclass(frozen=True)
+class Option:
+    """One configurable setting. Values are stored/compared as strings because
+    that is how environment variables behave."""
+
+    key: str
+    section: str
+    label: str
+    description: str
+    type: str  # "str" | "int" | "bool" | "choice" | "secret"
+    default: str = ""
+    choices: tuple[str, ...] = ()
+    minimum: Optional[int] = None
+    maximum: Optional[int] = None
+    note: str = ""
+
+    @property
+    def is_secret(self) -> bool:
+        return self.type == "secret"
+
+
+OPTIONS: tuple[Option, ...] = (
+    # --- Credentials ---------------------------------------------------------
+    Option(
+        "GOOGLE_CLOUD_PROJECT", "Credentials", "BigQuery billing project",
+        "Google Cloud project ID that BigQuery prior-art searches are billed to "
+        "(free tier: 1 TiB/month). Required for BigQuery search.",
+        "str",
+    ),
+    Option(
+        "USPTO_API_KEY", "Credentials", "USPTO ODP API key",
+        "API key for the USPTO Open Data Portal (data.uspto.gov). Optional; "
+        "enables USPTO application/grant search.",
+        "secret",
+    ),
+    Option(
+        "EPO_OPS_KEY", "Credentials", "EPO OPS key",
+        "Consumer key for the EPO Open Patent Services API. Optional; enables "
+        "European patent biblio/claims lookup.",
+        "secret",
+    ),
+    Option(
+        "EPO_OPS_SECRET", "Credentials", "EPO OPS secret",
+        "Consumer secret paired with the EPO OPS key.",
+        "secret",
+    ),
+    Option(
+        "ANTHROPIC_API_KEY", "Credentials", "Anthropic API key",
+        "Used only for API-backed HyDE query expansion when HYDE_BACKEND=api. "
+        "Otherwise unused.",
+        "secret",
+    ),
+    Option(
+        "OPENAI_API_KEY", "Credentials", "OpenAI API key",
+        "Alternative backend for API HyDE query expansion (HYDE_BACKEND=api).",
+        "secret",
+    ),
+    # --- Search & performance ------------------------------------------------
+    Option(
+        "PATENT_BIGQUERY_MAX_BYTES_BILLED", "Search", "BigQuery cost cap (bytes)",
+        "Per-query scan ceiling for BigQuery. A title search scans ~15 GiB; an "
+        "abstract/claims search scans ~200+ GiB, so the 25 GiB default blocks "
+        "full-text search until raised.",
+        "int", default=str(25 * GIB), minimum=GIB,
+        note="250 GiB ~= $1.30/query at on-demand pricing.",
+    ),
+    Option(
+        "HYDE_BACKEND", "Search", "HyDE backend",
+        "Query-expansion backend. 'api' uses Anthropic/OpenAI (consumes API "
+        "quota); empty uses the local model.",
+        "choice", default="", choices=("", "api"),
+    ),
+    Option(
+        "PATENT_MPEP_USE_HYDE", "Search", "Enable HyDE expansion",
+        "Whether MPEP semantic search expands the query with a hypothetical "
+        "document before retrieval.",
+        "bool", default="true",
+    ),
+    Option(
+        "PATENT_ENABLE_ANTECEDENT_CHECK", "Search", "Claim antecedent-basis check",
+        "Enable the (slower) antecedent-basis analysis when checking claims.",
+        "bool", default="false",
+    ),
+    Option(
+        "PATENT_MPEP_DEVICE", "Performance", "Embedding device",
+        "Compute device for the embedding model. 'auto' picks the best "
+        "available; 'mps' (Apple) is opt-in because it can be slower than CPU.",
+        "choice", default="", choices=("", "auto", "cpu", "gpu", "cuda", "mps"),
+    ),
+    Option(
+        "FORCE_CPU", "Performance", "Force CPU",
+        "Force CPU for embeddings even if a GPU is present.",
+        "bool", default="false",
+    ),
+    Option(
+        "PATENT_TORCH_CUDA", "Performance", "CUDA wheel override",
+        "Pin the PyTorch CUDA build used by setup when auto-detection can't "
+        "determine the GPU architecture. Empty = auto-detect.",
+        "choice", default="", choices=("", "cu126", "cu128"),
+    ),
+    Option(
+        "PATENT_LOG_LEVEL", "Performance", "Log level",
+        "Logging verbosity for the server.",
+        "choice", default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+    ),
+)
+
+OPTIONS_BY_KEY: dict[str, Option] = {o.key: o for o in OPTIONS}
+
+_BOOL_TRUE = {"1", "true", "yes", "on"}
+_BOOL_FALSE = {"0", "false", "no", "off", ""}
+
+
+def config_dir() -> Path:
+    """Platform config directory (override with PATENT_CONFIG_DIR)."""
+    override = os.environ.get("PATENT_CONFIG_DIR")
+    if override:
+        return Path(override)
+    if os.name == "nt":
+        base = os.environ.get("APPDATA") or str(Path.home())
+        return Path(base) / APP_DIR_NAME
+    return Path.home() / ".config" / APP_DIR_NAME
+
+
+def config_path() -> Path:
+    return config_dir() / "config.json"
+
+
+def load_file() -> dict[str, str]:
+    """Load known settings from the config file (unknown keys ignored)."""
+    path = config_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {k: str(v) for k, v in data.items() if k in OPTIONS_BY_KEY}
+
+
+def save_value(key: str, value: str) -> Path:
+    """Persist a single setting (merging with the existing file)."""
+    return save_values({key: value})
+
+
+def save_values(values: dict[str, str]) -> Path:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    current = load_file()
+    for key, value in values.items():
+        if key not in OPTIONS_BY_KEY:
+            raise KeyError(f"Unknown setting: {key}")
+        current[key] = str(value)
+    # Drop blanks so the file stays minimal.
+    clean = {k: v for k, v in current.items() if v != ""}
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(clean, fh, indent=2, sort_keys=True)
+    tmp.replace(path)
+    # best-effort: secrets live here, so restrict perms where supported
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)
+    return path
+
+
+def unset_value(key: str) -> Path:
+    if key not in OPTIONS_BY_KEY:
+        raise KeyError(f"Unknown setting: {key}")
+    path = config_path()
+    current = load_file()
+    current.pop(key, None)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump({k: v for k, v in current.items() if v != ""}, fh, indent=2, sort_keys=True)
+    tmp.replace(path)
+    return path
+
+
+def get_effective(key: str) -> tuple[str, str]:
+    """Return (value, source) for a key. source is 'env', 'file', or 'default'.
+    An empty environment variable is treated as unset."""
+    if key not in OPTIONS_BY_KEY:
+        raise KeyError(f"Unknown setting: {key}")
+    env = os.environ.get(key)
+    if env not in (None, ""):
+        return env, "env"  # type: ignore[return-value]
+    file_vals = load_file()
+    if file_vals.get(key, "") != "":
+        return file_vals[key], "file"
+    return OPTIONS_BY_KEY[key].default, "default"
+
+
+def validate(key: str, value: str) -> Optional[str]:
+    """Return an error message if value is invalid for key, else None."""
+    if key not in OPTIONS_BY_KEY:
+        return f"Unknown setting: {key}"
+    opt = OPTIONS_BY_KEY[key]
+    if opt.type == "int":
+        try:
+            number = int(value)
+        except ValueError:
+            return "must be an integer"
+        if opt.minimum is not None and number < opt.minimum:
+            return f"must be >= {opt.minimum}"
+        if opt.maximum is not None and number > opt.maximum:
+            return f"must be <= {opt.maximum}"
+    elif opt.type == "bool":
+        if value.lower() not in _BOOL_TRUE | _BOOL_FALSE:
+            return "must be true or false"
+    elif opt.type == "choice":
+        if value != "" and value not in opt.choices:
+            allowed = ", ".join(c for c in opt.choices if c)
+            return f"must be one of: {allowed}"
+    return None
+
+
+def normalize(key: str, value: str) -> str:
+    """Canonicalize a validated value (bools -> true/false)."""
+    opt = OPTIONS_BY_KEY[key]
+    if opt.type == "bool":
+        return "true" if value.lower() in _BOOL_TRUE else "false"
+    return value
+
+
+def apply_config_to_env() -> None:
+    """Inject file-backed settings into the environment for keys the environment
+    does not already define, so existing os.environ readers pick them up.
+    A real environment variable is never overridden."""
+    for key, value in load_file().items():
+        if value != "" and os.environ.get(key, "") == "":
+            os.environ[key] = value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,123 @@
+"""Tests for the central configuration schema and file-backed store."""
+
+import importlib
+
+import pytest
+
+from mcp_server import config as cfg
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Point the config store at a temp dir and clear relevant env vars."""
+    monkeypatch.setenv("PATENT_CONFIG_DIR", str(tmp_path))
+    for opt in cfg.OPTIONS:
+        monkeypatch.delenv(opt.key, raising=False)
+    yield
+
+
+class TestSchema:
+    def test_every_option_is_well_formed(self):
+        for opt in cfg.OPTIONS:
+            assert opt.key and opt.label and opt.description and opt.section
+            assert opt.type in {"str", "int", "bool", "choice", "secret"}
+            if opt.type == "choice":
+                assert opt.choices, f"{opt.key} is a choice with no choices"
+                # A non-empty default must be one of the choices.
+                if opt.default:
+                    assert opt.default in opt.choices
+            if opt.type == "bool":
+                assert opt.default in {"true", "false"}
+
+    def test_keys_are_unique(self):
+        keys = [o.key for o in cfg.OPTIONS]
+        assert len(keys) == len(set(keys))
+
+
+class TestValidate:
+    def test_int_rejects_non_int_and_below_min(self):
+        key = "PATENT_BIGQUERY_MAX_BYTES_BILLED"
+        assert cfg.validate(key, "abc") is not None
+        assert cfg.validate(key, "1") is not None  # below 1 GiB minimum
+        assert cfg.validate(key, str(250 * cfg.GIB)) is None
+
+    def test_choice_rejects_unknown(self):
+        assert cfg.validate("PATENT_LOG_LEVEL", "LOUD") is not None
+        assert cfg.validate("PATENT_LOG_LEVEL", "DEBUG") is None
+
+    def test_bool_accepts_common_forms(self):
+        for good in ("true", "false", "yes", "no", "1", "0"):
+            assert cfg.validate("FORCE_CPU", good) is None
+        assert cfg.validate("FORCE_CPU", "maybe") is not None
+
+    def test_unknown_key(self):
+        assert cfg.validate("NOPE", "x") is not None
+
+
+class TestNormalize:
+    def test_bool_canonicalized(self):
+        assert cfg.normalize("FORCE_CPU", "yes") == "true"
+        assert cfg.normalize("FORCE_CPU", "0") == "false"
+
+    def test_non_bool_passthrough(self):
+        assert cfg.normalize("GOOGLE_CLOUD_PROJECT", "my-proj") == "my-proj"
+
+
+class TestStoreRoundTrip:
+    def test_save_then_load(self):
+        cfg.save_value("GOOGLE_CLOUD_PROJECT", "proj-123")
+        assert cfg.load_file()["GOOGLE_CLOUD_PROJECT"] == "proj-123"
+
+    def test_unknown_key_rejected_on_save(self):
+        with pytest.raises(KeyError):
+            cfg.save_value("NOT_A_SETTING", "x")
+
+    def test_unset_removes_key(self):
+        cfg.save_value("FORCE_CPU", "true")
+        cfg.unset_value("FORCE_CPU")
+        assert "FORCE_CPU" not in cfg.load_file()
+
+    def test_blank_values_not_persisted(self):
+        cfg.save_value("GOOGLE_CLOUD_PROJECT", "")
+        assert "GOOGLE_CLOUD_PROJECT" not in cfg.load_file()
+
+
+class TestPrecedence:
+    def test_default_then_file_then_env(self, monkeypatch):
+        key = "PATENT_LOG_LEVEL"
+        assert cfg.get_effective(key) == ("INFO", "default")
+
+        cfg.save_value(key, "WARNING")
+        assert cfg.get_effective(key) == ("WARNING", "file")
+
+        monkeypatch.setenv(key, "ERROR")
+        assert cfg.get_effective(key) == ("ERROR", "env")
+
+    def test_empty_env_is_treated_as_unset(self, monkeypatch):
+        key = "GOOGLE_CLOUD_PROJECT"
+        cfg.save_value(key, "from-file")
+        monkeypatch.setenv(key, "")
+        assert cfg.get_effective(key) == ("from-file", "file")
+
+
+class TestApplyToEnv:
+    def test_bridges_file_into_env_when_unset(self, monkeypatch):
+        cfg.save_value("PATENT_LOG_LEVEL", "DEBUG")
+        monkeypatch.delenv("PATENT_LOG_LEVEL", raising=False)
+        cfg.apply_config_to_env()
+        import os
+
+        assert os.environ["PATENT_LOG_LEVEL"] == "DEBUG"
+
+    def test_does_not_override_real_env(self, monkeypatch):
+        cfg.save_value("PATENT_LOG_LEVEL", "DEBUG")
+        monkeypatch.setenv("PATENT_LOG_LEVEL", "ERROR")
+        cfg.apply_config_to_env()
+        import os
+
+        assert os.environ["PATENT_LOG_LEVEL"] == "ERROR"
+
+
+def test_module_reimport_is_stable():
+    """Re-importing config must not raise (schema is module-level)."""
+    importlib.reload(cfg)


### PR DESCRIPTION
Phase 1 of a configuration utility (foundation + CLI; a desktop GUI follows in a second PR).

## Why
All ~13 user-tunable settings — API keys, the BigQuery cost cap, embedding device, HyDE, log level, etc. — were settable **only via environment variables**, read through scattered `os.environ.get()` calls with no single source of truth. That's painful for non-developers (especially on Windows) and there was no way to see "what are my options and current values?"

## What
**`mcp_server/config.py` — one schema, one store.**
- `OPTIONS` declares every setting: label, description, type, default, validation rules, and cost notes (e.g. the 25 GiB BigQuery cap that blocks full-text search).
- File-backed JSON store in the platform config dir (override with `PATENT_CONFIG_DIR`).
- Resolution order: **environment variable > config file > default** — an explicitly-set env var always wins.
- `apply_config_to_env()` bridges the file into the environment at server startup, so **every existing `os.environ` reader keeps working unchanged** (no call sites rewritten). Secret files are `chmod 600` where supported.

**`patent-creator config` CLI:** `list` / `get` / `set` / `unset` / `path` — with validation, secret masking, and the cost note surfaced on `set`.

**Robustness:** `config` works even when the heavy stack (mcp/torch/faiss) can't load — exactly when you'd be fixing settings. The heavy imports in `cli.py` are guarded (and their import-time stderr suppressed on failure); heavy commands are gated centrally with a clear message.

`serve` now applies the config file before launching the server subprocess.

## Example
```
$ patent-creator config set PATENT_BIGQUERY_MAX_BYTES_BILLED 268435456000
[OK] PATENT_BIGQUERY_MAX_BYTES_BILLED = 268435456000
     250 GiB ~= $1.30/query at on-demand pricing.
$ patent-creator config list
== Search ==
  PATENT_BIGQUERY_MAX_BYTES_BILLED
      = 268435456000   [file]
      Per-query scan ceiling for BigQuery. A title search scans ~15 GiB; an
      abstract/claims search scans ~200+ GiB ...
```

## Verification
- **126 tests pass** (incl. 17 new config tests: schema integrity, validation, normalize, round-trip, precedence, env-bridge); ruff clean.
- `config set/get/list/path/unset` exercised end-to-end via the installed entry point.

Next PR: a small Tkinter desktop window driven by this same schema (so the option list never drifts).

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi