### PR TITLE
feat: desktop settings GUI (patent-creator config --gui)

### DIFF
--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -1038,8 +1038,17 @@ def config_path_command(args):
     return 0
 
 
+def config_gui_command(args):
+    """Launch the desktop settings window."""
+    from config_gui import launch
+
+    return launch()
+
+
 def config_command(args):
-    """Dispatch `config` with no subaction to the listing."""
+    """Dispatch bare `config`: GUI with --gui, otherwise the listing."""
+    if getattr(args, "gui", False):
+        return config_gui_command(args)
     return config_list_command(args)
 
 
@@ -1119,6 +1128,9 @@ For more information: https://github.com/RobThePCGuy/Claude-Patent-Creator
     # Config command (view/edit settings)
     config_parser = subparsers.add_parser(
         "config", help="View or change settings (API keys, BigQuery cap, device, ...)"
+    )
+    config_parser.add_argument(
+        "--gui", action="store_true", help="Open the desktop settings window"
     )
     config_parser.set_defaults(func=config_command)
     config_sub = config_parser.add_subparsers(dest="config_action")

--- a/mcp_server/config_gui.py
+++ b/mcp_server/config_gui.py
@@ -1,0 +1,144 @@
+"""Optional desktop GUI for editing settings (``patent-creator config --gui``).
+
+A thin Tkinter form generated from the :data:`mcp_server.config.OPTIONS` schema,
+so the list of options never drifts from the single source of truth. All
+validation and persistence are delegated to :mod:`mcp_server.config`; this module
+only builds widgets. Tkinter is imported lazily inside :func:`launch` so importing
+this module never requires a display.
+"""
+
+import sys
+
+# Work both as a package module (tests: mcp_server.config_gui) and as a bare
+# module under the CLI's sys.path setup (cli.py: from config_gui import launch).
+try:
+    from . import config as _config
+except ImportError:  # pragma: no cover - exercised only via the CLI entry point
+    import config as _config
+
+
+_DEFAULT_LABEL = "(default)"
+
+
+def _choice_display(value: str) -> str:
+    return _DEFAULT_LABEL if value == "" else value
+
+
+def _choice_value(display: str) -> str:
+    return "" if display == _DEFAULT_LABEL else display
+
+
+def launch() -> int:
+    """Open the settings window. Returns a process exit code."""
+    try:
+        import tkinter as tk
+        from tkinter import messagebox, ttk
+    except Exception as exc:  # tkinter missing or no display
+        print(
+            "[X] The settings GUI is unavailable (Tkinter not installed or no display).",
+            file=sys.stderr,
+        )
+        print(f"    {exc}", file=sys.stderr)
+        print(
+            "    Use the command line instead, e.g.:\n"
+            "      patent-creator config set GOOGLE_CLOUD_PROJECT my-project-id",
+            file=sys.stderr,
+        )
+        return 1
+
+    root = tk.Tk()
+    root.title("Claude Patent Creator - Settings")
+    root.minsize(560, 480)
+
+    # Scrollable body so the form never overflows small screens.
+    outer = ttk.Frame(root)
+    outer.pack(fill="both", expand=True)
+    canvas = tk.Canvas(outer, highlightthickness=0)
+    scrollbar = ttk.Scrollbar(outer, orient="vertical", command=canvas.yview)
+    body = ttk.Frame(canvas)
+    body.bind("<Configure>", lambda _e: canvas.configure(scrollregion=canvas.bbox("all")))
+    canvas.create_window((0, 0), window=body, anchor="nw")
+    canvas.configure(yscrollcommand=scrollbar.set)
+    canvas.pack(side="left", fill="both", expand=True)
+    scrollbar.pack(side="right", fill="y")
+
+    header = ttk.Label(
+        body,
+        text=f"Config file: {_config.config_path()}\n"
+        "Priority: environment variable > this file > default",
+        justify="left",
+    )
+    header.grid(row=0, column=0, columnspan=2, sticky="w", padx=12, pady=(12, 8))
+
+    widgets: dict = {}  # key -> (option, tk variable)
+    grid_row = 1
+    sections: dict = {}
+    for opt in _config.OPTIONS:
+        sections.setdefault(opt.section, []).append(opt)
+
+    for section, opts in sections.items():
+        frame = ttk.LabelFrame(body, text=section)
+        frame.grid(row=grid_row, column=0, columnspan=2, sticky="ew", padx=12, pady=6)
+        frame.columnconfigure(1, weight=1)
+        grid_row += 1
+
+        for inner_row, opt in enumerate(opts):
+            value, source = _config.get_effective(opt.key)
+            ttk.Label(frame, text=opt.label).grid(
+                row=inner_row * 2, column=0, sticky="nw", padx=8, pady=(8, 0)
+            )
+
+            if opt.type == "bool":
+                var = tk.BooleanVar(value=value.lower() == "true")
+                ttk.Checkbutton(frame, variable=var).grid(
+                    row=inner_row * 2, column=1, sticky="w", padx=8, pady=(8, 0)
+                )
+            elif opt.type == "choice":
+                var = tk.StringVar(value=_choice_display(value))
+                ttk.Combobox(
+                    frame,
+                    textvariable=var,
+                    values=[_choice_display(c) for c in opt.choices],
+                    state="readonly",
+                ).grid(row=inner_row * 2, column=1, sticky="ew", padx=8, pady=(8, 0))
+            else:
+                var = tk.StringVar(value=value)
+                ttk.Entry(
+                    frame,
+                    textvariable=var,
+                    show="•" if opt.is_secret else "",
+                ).grid(row=inner_row * 2, column=1, sticky="ew", padx=8, pady=(8, 0))
+
+            desc = opt.description + (f"  ({opt.note})" if opt.note else "")
+            ttk.Label(
+                frame, text=f"{desc}   [source: {source}]", foreground="#666", wraplength=460
+            ).grid(row=inner_row * 2 + 1, column=0, columnspan=2, sticky="w", padx=8, pady=(0, 4))
+
+            widgets[opt.key] = (opt, var)
+
+    def on_save():
+        errors = []
+        to_save = {}
+        for key, (opt, var) in widgets.items():
+            raw = var.get()
+            if isinstance(raw, bool):
+                raw = "true" if raw else "false"
+            raw = _choice_value(str(raw)) if opt.type == "choice" else str(raw)
+            err = _config.validate(key, raw)
+            if err:
+                errors.append(f"{opt.label}: {err}")
+                continue
+            to_save[key] = _config.normalize(key, raw)
+        if errors:
+            messagebox.showerror("Invalid settings", "\n".join(errors))
+            return
+        _config.save_values(to_save)
+        messagebox.showinfo("Saved", f"Settings saved to\n{_config.config_path()}")
+
+    buttons = ttk.Frame(root)
+    buttons.pack(fill="x", padx=12, pady=10)
+    ttk.Button(buttons, text="Save", command=on_save).pack(side="right")
+    ttk.Button(buttons, text="Close", command=root.destroy).pack(side="right", padx=(0, 8))
+
+    root.mainloop()
+    return 0

--- a/tests/test_config_gui.py
+++ b/tests/test_config_gui.py
@@ -1,0 +1,39 @@
+"""Tests for the optional settings GUI.
+
+The GUI is thin glue over the (already tested) config store, so these tests
+cover the pure helpers and that the module imports without a display. The
+widget-building path is exercised only when a Tk display is actually available
+(skipped on headless CI).
+"""
+
+import pytest
+
+from mcp_server import config_gui
+
+
+def test_choice_display_roundtrip():
+    assert config_gui._choice_display("") == "(default)"
+    assert config_gui._choice_display("cu126") == "cu126"
+    assert config_gui._choice_value("(default)") == ""
+    assert config_gui._choice_value("cu126") == "cu126"
+
+
+def test_module_imports_without_display():
+    # Importing the module must never require tkinter or a display.
+    assert callable(config_gui.launch)
+
+
+def test_launch_builds_form_when_display_available(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATENT_CONFIG_DIR", str(tmp_path))
+    try:
+        import tkinter
+    except Exception:  # pragma: no cover
+        pytest.skip("tkinter not installed")
+    try:
+        tkinter.Tk().destroy()  # probe for a usable display
+    except Exception:  # pragma: no cover - headless CI
+        pytest.skip("no Tk display available")
+
+    # Don't block on the event loop; just confirm the form builds cleanly.
+    monkeypatch.setattr(tkinter.Tk, "mainloop", lambda self: None)
+    assert config_gui.launch() == 0


### PR DESCRIPTION
Phase 2 of the config utility (Phase 1 = schema + CLI in #38). A small Tkinter window for point-and-click editing — for when the terminal isn't your thing.

## What
- **`mcp_server/config_gui.py`** — a form generated from the *same* `config.OPTIONS` schema as the CLI, so the two can never drift. Sections → labeled frames; `bool` → checkbox, `choice` → dropdown, `secret` → masked entry, others → text entry. Each field shows its description, cost note, and current **source** (env/file/default), pre-filled with the effective value. **Save** validates every field via `config.validate` and persists with `config.save_values`. The body scrolls so it fits small screens.
- Tkinter is imported **lazily** inside `launch()` — importing the module never needs a display, and `launch()` degrades with a clear message (pointing at the CLI) when Tkinter/display is unavailable (e.g. headless servers).
- Wired as **`patent-creator config --gui`**.

## Verification
- ruff clean; **129 tests pass** — GUI helper + import-safety tests, plus a display-guarded build test that constructed the full form here without error.
- Confirmed visually with a rendered screenshot of the live window (sectioned layout, masked secrets, per-field source labels).

Together with #38 this gives three ways to manage every setting — `config set`, `config list`, and now `config --gui` — all from one schema.

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi