### PR TITLE
feat: raise default BigQuery cost cap to 350 GiB

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -76,9 +76,12 @@ class BigQueryPatentSearch:
     TABLE_ID = "publications"
     FULL_TABLE_ID = f"{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}"
 
-    # Per-query bytes-billed ceiling. Defaults to 25 GiB; override via
-    # PATENT_BIGQUERY_MAX_BYTES_BILLED.
-    DEFAULT_MAX_BYTES_BILLED = 25 * 1024**3
+    # Per-query bytes-billed ceiling; override via PATENT_BIGQUERY_MAX_BYTES_BILLED.
+    # Defaults to 350 GiB so a normal keyword prior-art search works out of the
+    # box: the default search spans title+abstract+claims, which scans ~325 GiB
+    # of the public corpus (~$2.15/query at $6.25/TiB). A free dry-run still
+    # estimates each query and fails fast before anything larger is billed.
+    DEFAULT_MAX_BYTES_BILLED = 350 * 1024**3
     QUERY_TIMEOUT_SECONDS = 30
 
     def __init__(self, project_id: Optional[str] = None):

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -86,11 +86,12 @@ OPTIONS: tuple[Option, ...] = (
     # --- Search & performance ------------------------------------------------
     Option(
         "PATENT_BIGQUERY_MAX_BYTES_BILLED", "Search", "BigQuery cost cap (bytes)",
-        "Per-query scan ceiling for BigQuery. A title search scans ~15 GiB; an "
-        "abstract/claims search scans ~200+ GiB, so the 25 GiB default blocks "
-        "full-text search until raised.",
-        "int", default=str(25 * GIB), minimum=GIB,
-        note="250 GiB ~= $1.30/query at on-demand pricing.",
+        "Per-query scan ceiling for BigQuery. A title-only search scans ~18 GiB; "
+        "the default title+abstract+claims search scans ~325 GiB. The 350 GiB "
+        "default lets a normal search run; lower it to cap spend, raise it for "
+        "broader queries. A free dry-run estimate fails fast before overspending.",
+        "int", default=str(350 * GIB), minimum=GIB,
+        note="350 GiB ~= $2.15/query at $6.25/TiB on-demand pricing.",
     ),
     Option(
         "HYDE_BACKEND", "Search", "HyDE backend",


### PR DESCRIPTION
The 25 GiB default cap blocked every real keyword prior-art search. Measured against the live `patents-public-data` corpus:

| Search | Scan |
|--------|------|
| title only | ~18 GiB |
| title + abstract | ~211 GiB |
| **title + abstract + claims (the default)** | **~325 GiB** |

So out of the box, a standard search always hit `bytesBilledLimitExceeded`.

This raises `DEFAULT_MAX_BYTES_BILLED` and the config-schema default to **350 GiB** (~$2.15/query at $6.25/TiB), so a normal search runs unconfigured. The free dry-run pre-check still estimates each query and fails fast before anything larger is billed, and the cap is one `config set` / GUI toggle away.

Also corrects the cost note (the old "~$1.30" understated it — on-demand BigQuery is $6.25/TiB) and the option description with the real measured scan sizes.

Verified: 129 tests pass; ruff clean.

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi