### PR TITLE
fix: address code-review findings (search + config)

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -307,22 +307,33 @@ class BigQueryPatentSearch:
         # multi-word query no longer requires one verbatim phrase to match.
         # Wrap a substring in "double quotes" to force exact-phrase matching.
         terms = self._tokenize_query(query)
-        if not terms:
-            terms = [query.strip().lower()]  # degenerate input: match as-is
+
+        # Bail out instead of emitting a predicate-less query that would scan and
+        # bill the entire corpus and return everything: this happens for an
+        # empty/operator-only query (no terms) or when the only requested field
+        # is claims on a non-US country (no field_exprs, since non-US has no
+        # claims full-text here).
+        if not terms or not field_exprs:
+            if LOGGING_AVAILABLE and logger:
+                logger.info("bigquery_search_no_predicate", extra=log_extra)
+            return []
 
         relevance_parts: list[str] = []
-        if field_exprs:
-            for i, term in enumerate(terms):
-                pname = f"term{i}"
-                parameters.append(
-                    bigquery.ScalarQueryParameter(pname, "STRING", f"%{term}%")  # type: ignore[union-attr]
+        for i, term in enumerate(terms):
+            pname = f"term{i}"
+            # Escape LIKE metacharacters so a term containing % or _ (or the
+            # backslash escape char) matches literally instead of acting as a
+            # wildcard — otherwise a stray "%" would match every row.
+            escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            parameters.append(
+                bigquery.ScalarQueryParameter(pname, "STRING", f"%{escaped}%")  # type: ignore[union-attr]
+            )
+            term_clause = " OR ".join(f"{expr} LIKE @{pname}" for expr, _ in field_exprs)
+            conditions.append(f"({term_clause})")
+            for expr, weight in field_exprs:
+                relevance_parts.append(
+                    f"CASE WHEN {expr} LIKE @{pname} THEN {weight} ELSE 0 END"
                 )
-                term_clause = " OR ".join(f"{expr} LIKE @{pname}" for expr, _ in field_exprs)
-                conditions.append(f"({term_clause})")
-                for expr, weight in field_exprs:
-                    relevance_parts.append(
-                        f"CASE WHEN {expr} LIKE @{pname} THEN {weight} ELSE 0 END"
-                    )
 
         relevance_expr = " + ".join(relevance_parts) if relevance_parts else "0"
 

--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -53,9 +53,14 @@ try:
         )
 
     _SERVER_IMPORT_ERROR = None
+    _SERVER_IMPORT_STDERR = ""
     sys.stderr.write(_server_import_stderr.getvalue())
 except (ImportError, SystemExit) as exc:  # SystemExit: server.py exits if mcp is missing
     _SERVER_IMPORT_ERROR = exc
+    # Keep the captured diagnostic (e.g. "mcp package not found") to show only if
+    # a command that actually needs the stack is run — see the guard in main().
+    # str(SystemExit(1)) is just "1", so this captured text is the real message.
+    _SERVER_IMPORT_STDERR = _server_import_stderr.getvalue()
     check_pytorch_installation = get_pytorch_install_command = None
     INDEX_DIR = MPEP_DIR = MPEP_DOWNLOAD_URL = MPEPIndex = None
     check_all_sources = check_mpep_pdfs = None
@@ -1161,10 +1166,10 @@ For more information: https://github.com/RobThePCGuy/Claude-Patent-Creator
     # `config` is intentionally usable without the heavy server stack, so users
     # can set credentials/options before everything else is installed.
     if args.command != "config" and _SERVER_IMPORT_ERROR is not None:
-        print(
-            f"[X] Could not load required dependencies: {_SERVER_IMPORT_ERROR}",
-            file=sys.stderr,
-        )
+        print("[X] Could not load required dependencies.", file=sys.stderr)
+        detail = _SERVER_IMPORT_STDERR.strip() or str(_SERVER_IMPORT_ERROR)
+        if detail:
+            print("    " + detail.replace("\n", "\n    "), file=sys.stderr)
         print(
             "    Install them with 'pip install \".[dev]\"' and retry. "
             "('patent-creator config' works without them.)",

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -171,42 +171,53 @@ def load_file() -> dict[str, str]:
     return {k: str(v) for k, v in data.items() if k in OPTIONS_BY_KEY}
 
 
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write ``data`` as JSON to ``path`` atomically, owner-readable only.
+
+    The temp file is created with 0o600 *before* the (secret-bearing) content is
+    written, so there is no window where it is world-readable, then renamed over
+    the target. On Windows ``chmod`` only toggles the read-only bit, so
+    confidentiality there relies on the user-profile ACL of the config dir.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+    except Exception:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+    tmp.replace(path)
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)
+
+
 def save_value(key: str, value: str) -> Path:
     """Persist a single setting (merging with the existing file)."""
     return save_values({key: value})
 
 
 def save_values(values: dict[str, str]) -> Path:
-    path = config_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
     current = load_file()
     for key, value in values.items():
         if key not in OPTIONS_BY_KEY:
             raise KeyError(f"Unknown setting: {key}")
         current[key] = str(value)
     # Drop blanks so the file stays minimal.
-    clean = {k: v for k, v in current.items() if v != ""}
-    tmp = path.with_suffix(".json.tmp")
-    with tmp.open("w", encoding="utf-8") as fh:
-        json.dump(clean, fh, indent=2, sort_keys=True)
-    tmp.replace(path)
-    # best-effort: secrets live here, so restrict perms where supported
-    with contextlib.suppress(OSError):
-        path.chmod(0o600)
+    path = config_path()
+    _atomic_write(path, {k: v for k, v in current.items() if v != ""})
     return path
 
 
 def unset_value(key: str) -> Path:
     if key not in OPTIONS_BY_KEY:
         raise KeyError(f"Unknown setting: {key}")
-    path = config_path()
     current = load_file()
     current.pop(key, None)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".json.tmp")
-    with tmp.open("w", encoding="utf-8") as fh:
-        json.dump({k: v for k, v in current.items() if v != ""}, fh, indent=2, sort_keys=True)
-    tmp.replace(path)
+    path = config_path()
+    _atomic_write(path, {k: v for k, v in current.items() if v != ""})
     return path
 
 

--- a/mcp_server/config_gui.py
+++ b/mcp_server/config_gui.py
@@ -28,6 +28,27 @@ def _choice_value(display: str) -> str:
     return "" if display == _DEFAULT_LABEL else display
 
 
+def _plan_save(entries):
+    """Decide what the GUI's Save should persist.
+
+    ``entries`` is an iterable of ``(option, current_value, original_value)``.
+    Only fields the user actually changed are persisted (so opening the window
+    never copies an env-sourced secret or a built-in default onto disk), and each
+    changed value is validated. Returns ``(to_save, errors)``.
+    """
+    to_save: dict = {}
+    errors: list = []
+    for opt, current, original in entries:
+        if current == original:
+            continue
+        error = _config.validate(opt.key, current)
+        if error:
+            errors.append(f"{opt.label}: {error}")
+            continue
+        to_save[opt.key] = _config.normalize(opt.key, current)
+    return to_save, errors
+
+
 def launch() -> int:
     """Open the settings window. Returns a process exit code."""
     try:
@@ -89,11 +110,13 @@ def launch() -> int:
             )
 
             if opt.type == "bool":
+                original = "true" if value.lower() == "true" else "false"
                 var = tk.BooleanVar(value=value.lower() == "true")
                 ttk.Checkbutton(frame, variable=var).grid(
                     row=inner_row * 2, column=1, sticky="w", padx=8, pady=(8, 0)
                 )
             elif opt.type == "choice":
+                original = value
                 var = tk.StringVar(value=_choice_display(value))
                 ttk.Combobox(
                     frame,
@@ -102,6 +125,7 @@ def launch() -> int:
                     state="readonly",
                 ).grid(row=inner_row * 2, column=1, sticky="ew", padx=8, pady=(8, 0))
             else:
+                original = value
                 var = tk.StringVar(value=value)
                 ttk.Entry(
                     frame,
@@ -114,26 +138,28 @@ def launch() -> int:
                 frame, text=f"{desc}   [source: {source}]", foreground="#666", wraplength=460
             ).grid(row=inner_row * 2 + 1, column=0, columnspan=2, sticky="w", padx=8, pady=(0, 4))
 
-            widgets[opt.key] = (opt, var)
+            # Keep the pre-filled value so Save only persists fields the user
+            # actually changed — never copying env-sourced secrets or defaults
+            # onto disk just because the window was opened.
+            widgets[opt.key] = (opt, var, original)
 
     def on_save():
-        errors = []
-        to_save = {}
-        for key, (opt, var) in widgets.items():
+        entries = []
+        for _key, (opt, var, original) in widgets.items():
             raw = var.get()
             if isinstance(raw, bool):
                 raw = "true" if raw else "false"
             raw = _choice_value(str(raw)) if opt.type == "choice" else str(raw)
-            err = _config.validate(key, raw)
-            if err:
-                errors.append(f"{opt.label}: {err}")
-                continue
-            to_save[key] = _config.normalize(key, raw)
+            entries.append((opt, raw, original))
+        to_save, errors = _plan_save(entries)
         if errors:
             messagebox.showerror("Invalid settings", "\n".join(errors))
             return
-        _config.save_values(to_save)
-        messagebox.showinfo("Saved", f"Settings saved to\n{_config.config_path()}")
+        if to_save:
+            _config.save_values(to_save)
+        messagebox.showinfo(
+            "Saved", f"Saved {len(to_save)} change(s) to\n{_config.config_path()}"
+        )
 
     buttons = ttk.Frame(root)
     buttons.pack(fill="x", padx=12, pady=10)

--- a/mcp_server/tools/epo_search_tools.py
+++ b/mcp_server/tools/epo_search_tools.py
@@ -295,7 +295,8 @@ def register_epo_tools(
             else:
                 log_info(
                     "get_epo_patent: got result",
-                    title=result.get("title", "")[:50],
+                    # title may be None (EP publication with no English title)
+                    title=(result.get("title") or "")[:50],
                     claims_length=result.get("claims_length", 0),
                     description_length=result.get("description_length", 0),
                 )

--- a/mcp_server/uspto_api.py
+++ b/mcp_server/uspto_api.py
@@ -542,7 +542,7 @@ class USPTOClient:
         # entry can arrive as a bare dict; coerce so iteration never walks dict
         # keys and raises AttributeError (mirrors the EPO parser's handling).
         inventors = []
-        inventor_bag = app_meta.get("inventorBag", [])
+        inventor_bag = app_meta.get("inventorBag") or []  # may be missing or null
         if isinstance(inventor_bag, dict):
             inventor_bag = [inventor_bag]
         for inv in inventor_bag:
@@ -552,7 +552,7 @@ class USPTOClient:
 
         # Extract applicants
         applicants = []
-        applicant_bag = app_meta.get("applicantBag", [])
+        applicant_bag = app_meta.get("applicantBag") or []  # may be missing or null
         if isinstance(applicant_bag, dict):
             applicant_bag = [applicant_bag]
         for app in applicant_bag:

--- a/tests/test_config_gui.py
+++ b/tests/test_config_gui.py
@@ -23,6 +23,27 @@ def test_module_imports_without_display():
     assert callable(config_gui.launch)
 
 
+def test_plan_save_persists_only_changed_validated_fields():
+    from mcp_server import config
+
+    opt_proj = config.OPTIONS_BY_KEY["GOOGLE_CLOUD_PROJECT"]
+    opt_cap = config.OPTIONS_BY_KEY["PATENT_BIGQUERY_MAX_BYTES_BILLED"]
+    opt_log = config.OPTIONS_BY_KEY["PATENT_LOG_LEVEL"]
+    opt_cpu = config.OPTIONS_BY_KEY["FORCE_CPU"]
+
+    entries = [
+        (opt_proj, "secret-from-env", "secret-from-env"),  # unchanged -> not saved
+        (opt_cap, "abc", str(25 * config.GIB)),            # changed but invalid
+        (opt_log, "DEBUG", "INFO"),                        # changed + valid
+        (opt_cpu, "true", "false"),                        # changed + valid
+    ]
+    to_save, errors = config_gui._plan_save(entries)
+
+    # Unchanged env-sourced value is never written to disk; invalid is rejected.
+    assert to_save == {"PATENT_LOG_LEVEL": "DEBUG", "FORCE_CPU": "true"}
+    assert len(errors) == 1 and "cost cap" in errors[0].lower()
+
+
 def test_launch_builds_form_when_display_available(monkeypatch, tmp_path):
     monkeypatch.setenv("PATENT_CONFIG_DIR", str(tmp_path))
     try:

--- a/tests/test_keyword_search.py
+++ b/tests/test_keyword_search.py
@@ -93,5 +93,23 @@ class TestGeneratedSQL:
     def test_claims_field_only_used_for_us(self):
         us = _run("sensor", country="US", search_fields=["claims"])
         assert "claims_localized" in us.sql
+        # Non-US has no claims full-text here. A claims-only search on EP must not
+        # emit a predicate-less query that scans everything — it returns nothing
+        # without ever touching BigQuery.
         ep = _run("sensor", country="EP", search_fields=["claims"])
-        assert "claims_localized" not in ep.sql
+        assert ep.sql is None
+
+    def test_like_metacharacters_are_escaped(self):
+        # % and _ are LIKE wildcards; a literal term must be escaped so it does
+        # not match unintended rows (a stray "%" would otherwise match everything).
+        client = _run("50%_off", country="US", search_fields=["title"])
+        term_values = [p.value for p in client.params if p.name.startswith("term")]
+        assert term_values == ["%50\\%\\_off%"]
+
+    def test_empty_query_issues_no_query(self):
+        client = _run("", country="US")
+        assert client.sql is None
+
+    def test_operator_only_query_issues_no_query(self):
+        client = _run("and or ( )", country="US")
+        assert client.sql is None


### PR DESCRIPTION
Adversarial review of this session's work (#35–#40) surfaced these real issues; all fixed with tests.

## High
- **LIKE metacharacters not escaped** (`bigquery_search.py`): a keyword term with `%` or `_` acted as a wildcard — a stray `%` matched *every* row (full-corpus scan + junk results); a backslash could error the query. Terms are now escaped before binding.
- **Predicate-less query = scan everything** (`bigquery_search.py`): an empty/operator-only query, or a claims-only search on a non-US country (no claims full-text here), fell through to `WHERE country_code = @country` and returned/billed the entire corpus. Both now short-circuit to `[]` without touching BigQuery.
- **`unset` stripped secret-file perms** (`config.py`): unsetting any key rewrote `config.json` with default (world-readable) perms, exposing the *remaining* secrets on POSIX. Fixed via a shared `_atomic_write` that sets `0o600` on the temp file **before** writing — also closing a brief exposure window in the normal save path. Windows caveat documented.

## Medium
- **Sibling None-title crash** (`tools/epo_search_tools.py`): the same `result.get("title", "")[:50]` bug fixed in #35 lived in `get_epo_patent`'s log line too → `TypeError` on EP patents without an English title. Guarded.
- **Broken dependency diagnostic** (`cli.py`): on a failed server import the captured stderr (e.g. "mcp package not found") was discarded and the user saw `...: 1`. The real message is now shown in the heavy-command guard, while `config` stays clean.
- **GUI Save over-persisted** (`config_gui.py`): opening the window and clicking Save wrote *every* field, copying env-only secrets and built-in defaults onto disk. Now persists only fields the user actually changed (new `_plan_save` helper).

## Low
- USPTO inventor/applicant bag hardened against a null-valued bag (`get(...) or []`).

## Verification
- **133 tests pass** (added: LIKE-escaping, empty-query short-circuit, changed-only GUI save); ruff clean. Happy path unchanged (normal terms have no `%`/`_`, so escaping is a no-op).

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi