### PR TITLE
fix: surface budget error from get_patent_details and correct cap docs

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -85,10 +85,10 @@ $env:VARIABLE_NAME
 - `EPO_OPS_KEY` / `EPO_OPS_SECRET` - EPO OPS API credentials (optional)
 - `HYDE_BACKEND` - Set to `api` to use Anthropic/OpenAI for HyDE query expansion
 - `PATENT_BIGQUERY_MAX_BYTES_BILLED` - Override the per-query BigQuery cost ceiling, in bytes
-  (default: 25 GiB). A broad keyword search across the full patents corpus can scan several
-  hundred GiB. When the estimated scan exceeds this ceiling, the search **fails fast with an
-  actionable error** (estimated size, suggested ceiling, and approximate cost) via a free
-  dry-run estimate, instead of running an expensive query or appearing to hang. To run such a
-  search, raise the ceiling (e.g. `429496729600` for ~400 GiB, roughly $2/query at on-demand
-  pricing) or narrow the search with `country` / `start_year` / `end_year` filters or more
-  specific keywords.
+  (default: 350 GiB, which covers a normal keyword prior-art search — those scan ~325 GiB of
+  the public corpus, roughly $2/query at on-demand pricing). When a query's estimated scan
+  exceeds this ceiling, the search **fails fast with an actionable error** (estimated size,
+  suggested ceiling, and approximate cost) via a free dry-run estimate, instead of running an
+  expensive query or appearing to hang. To run a larger search, raise the ceiling (e.g.
+  `536870912000` for ~500 GiB) or narrow the search with `country` / `start_year` /
+  `end_year` filters or more specific keywords.

--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -62,6 +62,13 @@ def _get_gcloud_credentials_path():
         return Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
 
 
+class BigQueryBudgetExceededError(ValueError):
+    """Raised when a query's dry-run estimate exceeds the bytes-billed ceiling.
+
+    Subclasses ValueError so existing callers that catch/expect ValueError keep
+    working, while paths that must not swallow it can re-raise by type."""
+
+
 class BigQueryPatentSearch:
     """
     Search patents using Google BigQuery Patents Public Data
@@ -529,6 +536,11 @@ class BigQueryPatentSearch:
             else:
                 print(f"BigQuery get patent error: {e}", file=sys.stderr)
 
+            # A budget rejection is actionable guidance, not "patent not found";
+            # surface it instead of collapsing it into None.
+            if isinstance(e, BigQueryBudgetExceededError):
+                raise
+
             return None
 
     def search_by_cpc(
@@ -865,7 +877,7 @@ class BigQueryPatentSearch:
         cap_gib = max_bytes / 1024**3
         suggested = int(estimate * 1.2)
         est_usd = estimate / 1024**4 * 6.25  # on-demand BigQuery: ~$6.25 per TiB scanned
-        raise ValueError(
+        raise BigQueryBudgetExceededError(
             f"Patent search would scan ~{est_gib:.0f} GiB, exceeding the per-query cost "
             f"cap of {cap_gib:.0f} GiB. Narrow the search (add country / start_year / "
             f"end_year filters or more specific keywords), or raise the cap by setting "

--- a/tests/test_bigquery_budget.py
+++ b/tests/test_bigquery_budget.py
@@ -69,3 +69,16 @@ def test_budget_guard_silent_when_estimate_unavailable(monkeypatch):
 
     # Swallows the dry-run failure and returns without raising.
     searcher._assert_within_budget("SELECT 1", [])
+
+
+def test_get_patent_details_surfaces_budget_error(monkeypatch):
+    """An over-budget details lookup must raise the actionable budget error,
+    not swallow it into a "patent not found" None."""
+    monkeypatch.delenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", raising=False)
+    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
+    searcher = _searcher_with_estimate(over)
+
+    with pytest.raises(ValueError) as exc:
+        searcher.get_patent_details("US1234567B2")
+
+    assert "PATENT_BIGQUERY_MAX_BYTES_BILLED" in str(exc.value)


### PR DESCRIPTION
## Summary

Follow-up to #28 (dry-run cost pre-flight), closing two gaps found while validating it against current main:

- **`get_patent_details` swallowed the budget error.** An over-budget details lookup logged the actionable message and then returned `None`, so the caller saw "patent not found" instead of guidance. The guard now raises a dedicated `BigQueryBudgetExceededError` (a `ValueError` subclass — existing callers and tests keep working), and `get_patent_details` re-raises it instead of collapsing it into `None`.
- **Docs still described the pre-#40 default.** `docs/ENVIRONMENT_VARIABLES.md` said the cost ceiling defaults to 25 GiB; #40 raised it to 350 GiB. Corrected, with the normal-search cost context.

## Testing

- New test: `test_get_patent_details_surfaces_budget_error` (written first, watched fail against the swallow, passes after the fix)
- Full suite: 138 passed; `ruff check .` clean