### PR TITLE
fix: guarantee actionable budget errors on every path and harden the guard

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -8,6 +8,7 @@ import os
 import platform
 import re
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Optional
 
@@ -35,6 +36,20 @@ except ImportError:
     track_performance = None
     OperationTimer = None
     LOGGING_AVAILABLE = False
+
+# Config layer (env > config file > default, schema-validated). Same dual
+# import style as the module itself (flat in the server process, packaged
+# in tests/skills).
+try:
+    import config as _config
+except ImportError:
+    try:
+        from mcp_server import config as _config
+    except ImportError:
+        _config = None
+
+GIB = 1024**3
+USD_PER_TIB = 6.25  # BigQuery on-demand price per TiB scanned
 
 
 def _get_gcloud_credentials_path():
@@ -377,7 +392,14 @@ class BigQueryPatentSearch:
         """
 
         try:
-            results = self._run_query(sql, parameters)
+            results = self._run_query(
+                sql,
+                parameters,
+                narrowing_hint=(
+                    "Narrow the search (add country / start_year / end_year "
+                    "filters or more specific keywords)."
+                ),
+            )
 
             # Process results
             patents = []
@@ -434,7 +456,14 @@ class BigQueryPatentSearch:
             patent_number: Patent publication number (e.g., "US10123456B2")
 
         Returns:
-            Patent details dictionary or None if not found
+            Patent details dictionary, or None only when the patent does not
+            exist in the corpus.
+
+        Raises:
+            BigQueryBudgetExceededError: query would exceed the cost cap.
+            Exception: query/auth/network failures propagate — they are not
+                collapsed into None, so callers can distinguish "not found"
+                from "lookup failed".
         """
         if not self.client:
             raise RuntimeError("BigQuery client not initialized")
@@ -536,12 +565,10 @@ class BigQueryPatentSearch:
             else:
                 print(f"BigQuery get patent error: {e}", file=sys.stderr)
 
-            # A budget rejection is actionable guidance, not "patent not found";
-            # surface it instead of collapsing it into None.
-            if isinstance(e, BigQueryBudgetExceededError):
-                raise
-
-            return None
+            # Errors are not "patent not found" — collapsing them into None made
+            # auth/network/budget failures masquerade as missing patents. None is
+            # reserved for a genuinely empty result set (handled above).
+            raise
 
     def search_by_cpc(
         self, cpc_code: str, limit: int = 20, country: str = "US"
@@ -826,15 +853,32 @@ class BigQueryPatentSearch:
             raise
 
     def _resolve_max_bytes_billed(self) -> int:
-        """Resolve the per-query bytes-billed ceiling (env override or default)."""
+        """Resolve the per-query bytes-billed ceiling.
+
+        Delegates to the config layer (env > config file > default, schema
+        minimum enforced) so this knob cannot diverge from what
+        ``patent-creator config`` validates and documents. Falls back to
+        env-only parsing when the config module is unavailable.
+        """
+        key = "PATENT_BIGQUERY_MAX_BYTES_BILLED"
+        if _config is not None:
+            raw, _source = _config.get_effective(key)
+            if _config.validate(key, raw) is None:
+                return int(raw)
+            if LOGGING_AVAILABLE and logger:
+                logger.warning(
+                    "patent_bigquery_max_bytes_billed_invalid",
+                    extra={"value": raw, "fallback_bytes": self.DEFAULT_MAX_BYTES_BILLED},
+                )
+            return self.DEFAULT_MAX_BYTES_BILLED
         max_bytes = self.DEFAULT_MAX_BYTES_BILLED
-        env_value = os.environ.get("PATENT_BIGQUERY_MAX_BYTES_BILLED")
+        env_value = os.environ.get(key)
         if env_value:
             try:
                 parsed = int(env_value)
             except ValueError:
                 parsed = 0
-            if parsed > 0:
+            if parsed >= GIB:
                 max_bytes = parsed
             elif LOGGING_AVAILABLE and logger:
                 logger.warning(
@@ -843,64 +887,123 @@ class BigQueryPatentSearch:
                 )
         return max_bytes
 
-    def _make_job_config(self, parameters: list) -> Any:
+    def _make_job_config(self, parameters: list, max_bytes: Optional[int] = None) -> Any:
         """Build a QueryJobConfig with parameters and the bytes-billed ceiling."""
         return bigquery.QueryJobConfig(  # type: ignore[union-attr]
             query_parameters=parameters,
-            maximum_bytes_billed=self._resolve_max_bytes_billed(),
+            maximum_bytes_billed=(
+                max_bytes if max_bytes is not None else self._resolve_max_bytes_billed()
+            ),
         )
 
-    def _assert_within_budget(self, sql: str, parameters: list) -> None:
+    @staticmethod
+    def _format_gib(num_bytes: float) -> str:
+        """Human-readable GiB amount that never rounds a real value to 0."""
+        gib = num_bytes / GIB
+        return f"{gib:.0f}" if gib >= 10 else f"{gib:.2f}"
+
+    def _budget_error(
+        self, estimate: Optional[int], max_bytes: int, narrowing_hint: str
+    ) -> "BigQueryBudgetExceededError":
+        """Build the actionable over-budget error for both the pre-flight
+        (estimate known) and the real query's cap rejection (estimate unknown)."""
+        hint = f"{narrowing_hint} " if narrowing_hint else ""
+        if estimate is None:
+            return BigQueryBudgetExceededError(
+                f"Patent search exceeded the per-query cost cap of "
+                f"{self._format_gib(max_bytes)} GiB. {hint}Or raise the cap via the "
+                f"PATENT_BIGQUERY_MAX_BYTES_BILLED setting (currently {max_bytes})."
+            )
+        suggested = int(estimate * 1.2)
+        est_usd = estimate / 1024**4 * USD_PER_TIB
+        return BigQueryBudgetExceededError(
+            f"Patent search would scan ~{self._format_gib(estimate)} GiB, exceeding "
+            f"the per-query cost cap of {self._format_gib(max_bytes)} GiB. {hint}"
+            f"Or raise the cap by setting PATENT_BIGQUERY_MAX_BYTES_BILLED={suggested} "
+            f"(~{self._format_gib(suggested)} GiB headroom; this query would bill "
+            f"~${est_usd:.2f} at on-demand pricing)."
+        )
+
+    def _assert_within_budget(
+        self,
+        sql: str,
+        parameters: list,
+        max_bytes: Optional[int] = None,
+        narrowing_hint: str = "",
+    ) -> None:
         """Estimate the query's scan size with a free dry run and fail loudly if it
         would exceed the bytes-billed ceiling.
 
-        Without this guard an over-budget query is either rejected mid-flight by
-        BigQuery with an opaque ``bytesBilledLimitExceeded`` 500 or appears to hang,
-        giving the caller no actionable signal. A dry run is free and near-instant, so
-        we surface a clear, actionable error *before* spending any query budget.
+        This is a fast-path courtesy check: the enforcement that always holds is
+        ``maximum_bytes_billed`` on the real query, whose rejection ``_run_query``
+        translates into the same actionable error. The dry run keeps the query
+        cache enabled so a re-run BigQuery would serve free (0 bytes billed,
+        exempt from the cap) estimates ~0 and passes.
         """
         if not self.client or bigquery is None:
             return
-        max_bytes = self._resolve_max_bytes_billed()
+        if max_bytes is None:
+            max_bytes = self._resolve_max_bytes_billed()
         try:
             dry_config = bigquery.QueryJobConfig(  # type: ignore[union-attr]
-                query_parameters=parameters, dry_run=True, use_query_cache=False
+                query_parameters=parameters, dry_run=True
             )
-            estimate = self.client.query(sql, job_config=dry_config).total_bytes_processed
-        except Exception:
-            # A failed estimate must never block the search; let the real query run
-            # and surface any genuine error itself.
+            estimate = self.client.query(
+                sql, job_config=dry_config, timeout=self.QUERY_TIMEOUT_SECONDS
+            ).total_bytes_processed
+        except Exception as e:
+            # A failed estimate must never block the search; the real query's own
+            # cap enforcement still holds and _run_query translates its rejection.
+            if LOGGING_AVAILABLE and logger:
+                logger.warning(
+                    "bigquery_budget_preflight_failed",
+                    extra={"error_type": type(e).__name__, "error_message": str(e)},
+                )
             return
         if estimate is None or estimate <= max_bytes:
             return
-        est_gib = estimate / 1024**3
-        cap_gib = max_bytes / 1024**3
-        suggested = int(estimate * 1.2)
-        est_usd = estimate / 1024**4 * 6.25  # on-demand BigQuery: ~$6.25 per TiB scanned
-        raise BigQueryBudgetExceededError(
-            f"Patent search would scan ~{est_gib:.0f} GiB, exceeding the per-query cost "
-            f"cap of {cap_gib:.0f} GiB. Narrow the search (add country / start_year / "
-            f"end_year filters or more specific keywords), or raise the cap by setting "
-            f"PATENT_BIGQUERY_MAX_BYTES_BILLED={suggested} "
-            f"(~{est_gib * 1.2:.0f} GiB, ~${est_usd:.2f} per query at on-demand pricing)."
-        )
+        raise self._budget_error(estimate, max_bytes, narrowing_hint)
 
-    def _run_query(self, sql: str, parameters: list) -> Any:
-        """Pre-flight the cost, then execute the query and return the row iterator."""
-        self._assert_within_budget(sql, parameters)
-        job_config = self._make_job_config(parameters)
-        if LOGGING_AVAILABLE and OperationTimer:
-            with OperationTimer("bigquery_query"):
+    @staticmethod
+    def _is_bytes_billed_rejection(exc: Exception) -> bool:
+        """Recognize BigQuery's maximum_bytes_billed rejection of a real query."""
+        for err in getattr(exc, "errors", None) or []:
+            if isinstance(err, dict) and err.get("reason") == "bytesBilledLimitExceeded":
+                return True
+        text = str(exc)
+        return "bytesBilledLimitExceeded" in text or "limit for bytes billed" in text.lower()
+
+    def _run_query(self, sql: str, parameters: list, narrowing_hint: str = "") -> Any:
+        """Pre-flight the cost, then execute the query and return the row iterator.
+
+        Guarantees an actionable ``BigQueryBudgetExceededError`` on every
+        over-budget path: the dry-run estimate when available, and translation
+        of the server's own ``bytesBilledLimitExceeded`` rejection otherwise.
+        """
+        max_bytes = self._resolve_max_bytes_billed()
+        self._assert_within_budget(sql, parameters, max_bytes, narrowing_hint)
+        job_config = self._make_job_config(parameters, max_bytes)
+        timer = (
+            OperationTimer("bigquery_query")
+            if LOGGING_AVAILABLE and OperationTimer
+            else nullcontext()
+        )
+        with timer:
+            try:
                 return self.client.query(sql, job_config=job_config).result(
                     timeout=self.QUERY_TIMEOUT_SECONDS
                 )
-        return self.client.query(sql, job_config=job_config).result(
-            timeout=self.QUERY_TIMEOUT_SECONDS
-        )
+            except BigQueryBudgetExceededError:
+                raise
+            except Exception as e:
+                if self._is_bytes_billed_rejection(e):
+                    raise self._budget_error(None, max_bytes, narrowing_hint) from e
+                raise
 
     def _format_date(self, date_int: Optional[int]) -> Optional[str]:
         """Convert YYYYMMDD integer to YYYY-MM-DD string"""
-        if not date_int:
+        # BigQuery SQL casts dates to STRING, so missing dates arrive as "0".
+        if not date_int or str(date_int) == "0":
             return None
 
         try:

--- a/skills/bigquery-patent-search/SKILL.md
+++ b/skills/bigquery-patent-search/SKILL.md
@@ -206,7 +206,7 @@ BigQuery pricing:
 - **First 1 TiB/month**: FREE
 - **After 1 TiB**: $6.25 per TiB queried (on-demand)
 - **Typical query**: 10-50 MB per search
-- **Bytes-billed ceiling**: enforced per-query via `PATENT_BIGQUERY_MAX_BYTES_BILLED` (default 25 GiB)
+- **Bytes-billed ceiling**: enforced per-query via `PATENT_BIGQUERY_MAX_BYTES_BILLED` (default 350 GiB)
 
 ## Tools Available
 

--- a/skills/patent-search/SKILL.md
+++ b/skills/patent-search/SKILL.md
@@ -26,7 +26,7 @@ This skill points Claude at the BigQuery patent-search tools registered by the p
 
 ## Cost notes
 
-BigQuery on-demand pricing is $6.25 / TiB (1 TiB free per month). The MCP server enforces a per-query bytes-billed ceiling, defaulting to 25 GiB. Override via `PATENT_BIGQUERY_MAX_BYTES_BILLED` if you need a larger scan window.
+BigQuery on-demand pricing is $6.25 / TiB (1 TiB free per month). The MCP server enforces a per-query bytes-billed ceiling, defaulting to 350 GiB. Override via `PATENT_BIGQUERY_MAX_BYTES_BILLED` if you need a larger scan window.
 
 ## Choosing keywords
 

--- a/tests/test_bigquery_budget.py
+++ b/tests/test_bigquery_budget.py
@@ -1,84 +1,213 @@
-"""Tests for the BigQuery per-query cost-budget pre-flight guard.
+"""Tests for the BigQuery per-query cost-budget guard.
 
 These verify that an over-budget query fails fast with an actionable error
-(via a free dry-run estimate) instead of being rejected mid-flight by BigQuery
-or appearing to hang. They use a mocked client, so no credentials or network.
+(via a free dry-run estimate) AND that the guarantee holds when the dry run
+is unavailable: a real query rejected by BigQuery's maximum_bytes_billed is
+translated into the same actionable error. Mocked client — no credentials
+or network.
 """
 
 from unittest.mock import MagicMock
 
 import pytest
 
-from mcp_server.bigquery_search import BigQueryPatentSearch
+from mcp_server.bigquery_search import (
+    BigQueryBudgetExceededError,
+    BigQueryPatentSearch,
+)
 
 
-def _searcher_with_estimate(estimated_bytes):
-    """Build a BigQueryPatentSearch whose dry run reports a fixed scan size,
-    bypassing real credentials/network (skips __init__)."""
+def _searcher(dry_estimate=None, query_side_effect=None, result_side_effect=None):
+    """Build a BigQueryPatentSearch with a mocked client, bypassing __init__.
+
+    dry_estimate: total_bytes_processed reported by every job object.
+    query_side_effect: raise from client.query itself (kills the dry run).
+    result_side_effect: raise from job.result() (kills the real query only).
+    """
     searcher = object.__new__(BigQueryPatentSearch)
     client = MagicMock()
-    client.query.return_value.total_bytes_processed = estimated_bytes
+    if query_side_effect is not None:
+        client.query.side_effect = query_side_effect
+    else:
+        job = client.query.return_value
+        job.total_bytes_processed = dry_estimate
+        if result_side_effect is not None:
+            job.result.side_effect = result_side_effect
+        else:
+            job.result.return_value = iter([])
     searcher.client = client
     return searcher
 
 
-def test_budget_guard_raises_when_estimate_exceeds_cap(monkeypatch):
+@pytest.fixture(autouse=True)
+def _hermetic_config(monkeypatch, tmp_path):
+    """Isolate tests from the developer's real env var and config file."""
     monkeypatch.delenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", raising=False)
-    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
-    searcher = _searcher_with_estimate(over)
+    monkeypatch.setenv("PATENT_CONFIG_DIR", str(tmp_path))
 
-    with pytest.raises(ValueError) as exc:
+
+def test_budget_guard_raises_specific_type_when_estimate_exceeds_cap():
+    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
+    searcher = _searcher(dry_estimate=over)
+
+    with pytest.raises(BigQueryBudgetExceededError) as exc:
         searcher._assert_within_budget("SELECT 1", [])
 
     msg = str(exc.value)
-    # The error is actionable: it names the cap, the override knob, and a remedy.
     assert "per-query cost cap" in msg
     assert "PATENT_BIGQUERY_MAX_BYTES_BILLED" in msg
 
 
-def test_budget_guard_allows_query_within_cap(monkeypatch):
-    monkeypatch.delenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", raising=False)
+def test_budget_guard_allows_query_within_cap():
     under = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED // 2
-    searcher = _searcher_with_estimate(under)
+    searcher = _searcher(dry_estimate=under)
 
-    # Within budget -> no exception.
     searcher._assert_within_budget("SELECT 1", [])
 
 
 def test_budget_guard_respects_env_override(monkeypatch):
     estimate = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 2
-    searcher = _searcher_with_estimate(estimate)
+    searcher = _searcher(dry_estimate=estimate)
 
-    # Cap raised above the estimate -> allowed.
     monkeypatch.setenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", str(estimate * 2))
     searcher._assert_within_budget("SELECT 1", [])
 
-    # Cap lowered below the estimate -> blocked.
     monkeypatch.setenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", str(estimate // 2))
-    with pytest.raises(ValueError):
+    with pytest.raises(BigQueryBudgetExceededError):
         searcher._assert_within_budget("SELECT 1", [])
 
 
-def test_budget_guard_silent_when_estimate_unavailable(monkeypatch):
-    """A failed dry run must not block the real query from running."""
-    monkeypatch.delenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", raising=False)
-    searcher = object.__new__(BigQueryPatentSearch)
-    client = MagicMock()
-    client.query.side_effect = RuntimeError("dry run failed")
-    searcher.client = client
+def test_env_below_schema_minimum_falls_back_to_default(monkeypatch):
+    """The config schema rejects caps under 1 GiB; the resolver must agree
+    instead of silently accepting a 5-byte cap that kills every query."""
+    monkeypatch.setenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", "5")
+    searcher = _searcher(dry_estimate=1)
 
-    # Swallows the dry-run failure and returns without raising.
+    assert searcher._resolve_max_bytes_billed() == BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED
+
+
+def test_config_file_value_respected(tmp_path):
+    """Documented resolution order is env > config file > default; with no
+    env var set, the config-file value must win over the default."""
+    two_gib = 2 * 1024**3
+    (tmp_path / "config.json").write_text(f'{{"PATENT_BIGQUERY_MAX_BYTES_BILLED": "{two_gib}"}}')
+    searcher = _searcher(dry_estimate=1)
+
+    assert searcher._resolve_max_bytes_billed() == two_gib
+
+
+def test_budget_guard_silent_when_estimate_unavailable():
+    """A failed dry run must not block the real query from running."""
+    searcher = _searcher(query_side_effect=RuntimeError("dry run failed"))
+
     searcher._assert_within_budget("SELECT 1", [])
 
 
-def test_get_patent_details_surfaces_budget_error(monkeypatch):
-    """An over-budget details lookup must raise the actionable budget error,
-    not swallow it into a "patent not found" None."""
-    monkeypatch.delenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", raising=False)
-    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
-    searcher = _searcher_with_estimate(over)
+def test_dry_run_is_time_bounded():
+    """The pre-flight must not reintroduce unbounded hangs: the dry-run API
+    call carries the same timeout as the real query."""
+    searcher = _searcher(dry_estimate=1)
 
-    with pytest.raises(ValueError) as exc:
+    searcher._assert_within_budget("SELECT 1", [])
+
+    _, kwargs = searcher.client.query.call_args
+    assert kwargs.get("timeout") == BigQueryPatentSearch.QUERY_TIMEOUT_SECONDS
+
+
+def test_dry_run_does_not_disable_query_cache():
+    """Cache-served re-runs bill 0 bytes and are exempt from the cap; the
+    dry run must not force a worst-case uncached estimate."""
+    searcher = _searcher(dry_estimate=1)
+
+    searcher._assert_within_budget("SELECT 1", [])
+
+    _, kwargs = searcher.client.query.call_args
+    assert kwargs["job_config"].use_query_cache is not False
+
+
+def test_real_query_cap_rejection_translated():
+    """When the dry run passes (or is skipped) but BigQuery rejects the real
+    query on maximum_bytes_billed, the opaque error must be translated into
+    the same actionable BigQueryBudgetExceededError."""
+    searcher = _searcher(
+        dry_estimate=1,
+        result_side_effect=Exception(
+            "403 Query exceeded limit for bytes billed: 375809638400. "
+            "reason: bytesBilledLimitExceeded"
+        ),
+    )
+
+    with pytest.raises(BigQueryBudgetExceededError) as exc:
+        searcher._run_query("SELECT 1", [])
+
+    assert "PATENT_BIGQUERY_MAX_BYTES_BILLED" in str(exc.value)
+
+
+def test_real_query_other_errors_not_translated():
+    searcher = _searcher(dry_estimate=1, result_side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError):
+        searcher._run_query("SELECT 1", [])
+
+
+def test_get_patent_details_surfaces_budget_error():
+    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
+    searcher = _searcher(dry_estimate=over)
+
+    with pytest.raises(BigQueryBudgetExceededError) as exc:
         searcher.get_patent_details("US1234567B2")
 
     assert "PATENT_BIGQUERY_MAX_BYTES_BILLED" in str(exc.value)
+
+
+def test_get_patent_details_surfaces_infrastructure_errors():
+    """Auth/network/config failures must not masquerade as 'patent not
+    found': they propagate instead of collapsing into None."""
+    searcher = _searcher(dry_estimate=1, result_side_effect=RuntimeError("auth expired"))
+
+    with pytest.raises(RuntimeError):
+        searcher.get_patent_details("US1234567B2")
+
+
+def test_keyword_budget_error_carries_narrowing_hint():
+    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
+    searcher = _searcher(dry_estimate=over)
+
+    with pytest.raises(BigQueryBudgetExceededError) as exc:
+        searcher.search_by_keywords("neural network")
+
+    assert "start_year" in str(exc.value)
+
+
+def test_family_budget_error_omits_keyword_hint():
+    """Remediation advice must match the query shape: family search has no
+    keyword/year filters, so the error must not suggest them."""
+    over = BigQueryPatentSearch.DEFAULT_MAX_BYTES_BILLED * 10
+    searcher = _searcher(dry_estimate=over)
+
+    with pytest.raises(BigQueryBudgetExceededError) as exc:
+        searcher.search_patent_family(12345)
+
+    msg = str(exc.value)
+    assert "start_year" not in msg
+    assert "PATENT_BIGQUERY_MAX_BYTES_BILLED" in msg
+
+
+def test_sub_gib_amounts_do_not_render_as_zero(monkeypatch):
+    """With a small cap, the message must not read '0 GiB exceeding 0 GiB'."""
+    monkeypatch.setenv("PATENT_BIGQUERY_MAX_BYTES_BILLED", str(2 * 1024**3))
+    searcher = _searcher(dry_estimate=3 * 1024**3 + 512 * 1024**2)  # 3.5 GiB
+
+    with pytest.raises(BigQueryBudgetExceededError) as exc:
+        searcher._assert_within_budget("SELECT 1", [])
+
+    assert "~0 GiB" not in str(exc.value)
+
+
+def test_format_date_handles_zero_string():
+    """BigQuery SQL casts dates to STRING, so a missing grant date arrives
+    as '0' — it must render as None, not the string '0'."""
+    searcher = object.__new__(BigQueryPatentSearch)
+    assert searcher._format_date("0") is None
+    assert searcher._format_date(0) is None
+    assert searcher._format_date("20210101") == "2021-01-01"

--- a/tests/test_keyword_search.py
+++ b/tests/test_keyword_search.py
@@ -39,6 +39,11 @@ class TestTokenizer:
 
 
 class _FakeQueryJob:
+    # Dry runs read total_bytes_processed off the job itself; keep it present
+    # so these tests exercise the budget guard instead of tripping its
+    # degrade-open exception path.
+    total_bytes_processed = 0
+
     def __init__(self):
         class _Result(list):
             total_bytes_processed = 0
@@ -55,7 +60,7 @@ class _FakeClient:
         self.sql = None
         self.params = None
 
-    def query(self, sql, job_config=None):
+    def query(self, sql, job_config=None, timeout=None):
         self.sql = sql
         self.params = job_config.query_parameters
         return _FakeQueryJob()
@@ -70,7 +75,9 @@ def _run(query, **kwargs):
 
 class TestGeneratedSQL:
     def test_each_term_becomes_its_own_anded_group(self):
-        client = _run("blockchain authentication", country="US", search_fields=["title", "abstract"])
+        client = _run(
+            "blockchain authentication", country="US", search_fields=["title", "abstract"]
+        )
         term_params = {p.name: p.value for p in client.params if p.name.startswith("term")}
         assert term_params == {"term0": "%blockchain%", "term1": "%authentication%"}
 


### PR DESCRIPTION
The dry-run pre-flight only delivered its actionable error when the dry run
succeeded; a failed dry run degraded open and the real query's own
maximum_bytes_billed rejection surfaced as the raw bytesBilledLimitExceeded
error. _run_query now translates that rejection into
BigQueryBudgetExceededError, making the dry run a fast-path courtesy rather
than the sole bearer of the guarantee.

Also:
- Bound the dry-run API call with QUERY_TIMEOUT_SECONDS (it previously had
  no deadline and could hang for the client library's full retry budget
  before the timeout-protected real query even started).
- Let the dry run use the query cache so re-runs BigQuery would serve free
  (0 bytes billed, exempt from the cap) estimate ~0 and pass.
- Resolve the cost cap through the config layer (env > config file >
  default, 1 GiB schema minimum) instead of a divergent hand-rolled parse
  that accepted a 5-byte cap the config CLI rejects, and resolve it once
  per query instead of twice.
- get_patent_details no longer collapses auth/network/config errors into
  None ('patent not found'); None is reserved for a genuinely absent
  patent, and the docstring documents what raises.
- Match remediation advice to the query shape: only keyword search suggests
  keyword/year filters; other shapes just point at the cap setting.
- Format sub-10-GiB amounts with decimals so small caps don't render as
  '0 GiB exceeding 0 GiB'; name the on-demand price once (USD_PER_TIB).
- _format_date: BigQuery casts dates to STRING, so missing grant dates
  arrived as '0' and rendered verbatim; they now map to None.
- Keyword-search test fakes now expose total_bytes_processed and accept the
  timeout kwarg, so the search-path suite exercises the guard instead of
  silently degrading it open; budget tests assert the specific exception
  type and are hermetic against the developer's real config file.
- Sync the stale 25 GiB default in two SKILL.md files with the 350 GiB
  default from #40.
