### PR TITLE
fix: disclose skipped checks in the claims compliance report

### DIFF
--- a/mcp_server/claims_analyzer.py
+++ b/mcp_server/claims_analyzer.py
@@ -5,6 +5,7 @@ Performs automated analysis of patent claims for 35 USC 112(b) compliance
 Based on research from plint, cgupatent/antecedent-check, and PEDANTIC
 """
 
+import os
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -178,9 +179,7 @@ class ClaimsAnalyzer(BaseAnalyzer):
         #
         # When enabled, all findings are emitted at LOW confidence requiring manual review.
         # Enable with: PATENT_ENABLE_ANTECEDENT_CHECK=1
-        import os
-
-        if os.environ.get("PATENT_ENABLE_ANTECEDENT_CHECK", "").strip() not in ("1", "true", "yes"):
+        if not self._antecedent_check_enabled():
             return
 
         claim_text = claim["text"]
@@ -468,6 +467,30 @@ class ClaimsAnalyzer(BaseAnalyzer):
             # Fallback for base issues (shouldn't happen in this analyzer)
             return super()._issue_to_dict(issue)
 
+    @staticmethod
+    def _antecedent_check_enabled() -> bool:
+        """Antecedent-basis checking is opt-in due to its false-positive rate."""
+        return os.environ.get("PATENT_ENABLE_ANTECEDENT_CHECK", "").strip() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    def _skipped_checks(self) -> list[dict[str, str]]:
+        """Checks that did not run in this analysis, with how to enable them."""
+        if self._antecedent_check_enabled():
+            return []
+        return [
+            {
+                "check": "antecedent_basis",
+                "reason": (
+                    "opt-in: pattern-based antecedent checking has a high "
+                    "false-positive rate, so it is disabled by default"
+                ),
+                "enable_with": "PATENT_ENABLE_ANTECEDENT_CHECK=1",
+            }
+        ]
+
     def _generate_report(self, claims: list[dict]) -> dict:
         """Generate comprehensive analysis report"""
         # Sort issues by severity and claim number
@@ -485,8 +508,17 @@ class ClaimsAnalyzer(BaseAnalyzer):
             len(claims), counts["critical"], counts["important"], counts["minor"]
         )
 
-        # Generate summary
+        # Generate summary — a clean result must not read as a full bill of
+        # health when a check was skipped.
         summary = self._generate_claims_summary(claims, counts)
+        checks_skipped = self._skipped_checks()
+        if checks_skipped:
+            skipped_names = ", ".join(c["check"] for c in checks_skipped)
+            summary += (
+                f" NOTE: the following checks were skipped: {skipped_names}. "
+                f"Enable with {checks_skipped[0]['enable_with']} (findings are "
+                f"LOW confidence and need manual review)."
+            )
 
         # Use base report generation
         additional_data = {
@@ -494,6 +526,7 @@ class ClaimsAnalyzer(BaseAnalyzer):
             "independent_count": sum(1 for c in claims if c["is_independent"]),
             "dependent_count": sum(1 for c in claims if not c["is_independent"]),
             "issues_by_type": {k: len(v) for k, v in issues_by_type.items()},
+            "checks_skipped": checks_skipped,
         }
 
         return self._generate_base_report(

--- a/tests/test_claims_skipped_check_disclosure.py
+++ b/tests/test_claims_skipped_check_disclosure.py
@@ -1,0 +1,54 @@
+"""The claims report must disclose checks that were skipped.
+
+Antecedent-basis checking is opt-in (high false-positive rate, see
+claims_analyzer.py), which is a defensible default — but a report that says
+"[OK] All claims are compliant" while silently skipping its headline check
+gives false assurance. The report must name skipped checks and how to
+enable them.
+"""
+
+import pytest
+
+from mcp_server.claims_analyzer import ClaimsAnalyzer
+
+FLAWED_CLAIM = "1. An apparatus comprising: the widget attached to said flange."
+
+
+@pytest.fixture
+def analyzer():
+    return ClaimsAnalyzer()
+
+
+def test_report_discloses_skipped_antecedent_check(analyzer, monkeypatch):
+    monkeypatch.delenv("PATENT_ENABLE_ANTECEDENT_CHECK", raising=False)
+
+    report = analyzer.analyze_claims(FLAWED_CLAIM)
+
+    skipped = report["checks_skipped"]
+    assert any(c["check"] == "antecedent_basis" for c in skipped)
+    assert any("PATENT_ENABLE_ANTECEDENT_CHECK" in c["enable_with"] for c in skipped)
+    # The summary must not read as a clean bill of health.
+    assert "skipped" in report["summary"].lower()
+    assert "PATENT_ENABLE_ANTECEDENT_CHECK" in report["summary"]
+
+
+def test_no_disclosure_when_check_enabled(analyzer, monkeypatch):
+    monkeypatch.setenv("PATENT_ENABLE_ANTECEDENT_CHECK", "1")
+
+    report = analyzer.analyze_claims(FLAWED_CLAIM)
+
+    assert report["checks_skipped"] == []
+    assert "skipped" not in report["summary"].lower()
+    # And the enabled check actually fires on the flawed claim.
+    assert report["issues_by_type"].get("antecedent_basis", 0) >= 1
+
+
+def test_clean_claims_with_all_checks_enabled_still_report_ok(analyzer, monkeypatch):
+    monkeypatch.setenv("PATENT_ENABLE_ANTECEDENT_CHECK", "1")
+
+    report = analyzer.analyze_claims(
+        "1. An apparatus comprising: a widget; and a flange attached to the widget."
+    )
+
+    assert report["total_issues"] == 0
+    assert report["summary"].startswith("[OK]")


### PR DESCRIPTION
review_patent_claims reported '[OK] All claims are compliant with 35 USC
112(b)' and a 100.0 compliance score even though antecedent-basis checking
— the analyzer's headline check — is opt-in and had silently not run. A
user with claims full of antecedent violations got a clean bill of health
with no hint that the relevant check was off.

The report now carries a checks_skipped list (check name, why it is off by
default, and the exact setting that enables it), and the summary appends a
NOTE naming the skipped checks. When PATENT_ENABLE_ANTECEDENT_CHECK is on,
nothing changes. The opt-in default itself is unchanged — pattern-based
antecedent checking has a documented false-positive rate; the fix is
honesty about coverage, not forcing the check on.
