### PR TITLE
fix: provision Graphviz during setup and report missing law corpora honestly

### DIFF
--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -455,6 +455,35 @@ def setup_bigquery_auth_prompt():
     return False
 
 
+def _setup_graphviz(ensure_fn=None) -> bool:
+    """Provision system Graphviz so the diagram tools work out of the box.
+
+    Best effort: any failure prints guidance and returns False without
+    blocking the rest of setup. ``ensure_fn`` is injectable for tests.
+    """
+    print("\nChecking Graphviz (diagram tools)...", file=sys.stderr)
+    if ensure_fn is None:
+        try:
+            from graphviz_installer import ensure_graphviz as ensure_fn
+        except ImportError:
+            try:
+                from mcp_server.graphviz_installer import ensure_graphviz as ensure_fn
+            except ImportError:
+                print("  [SKIP] graphviz_installer module unavailable", file=sys.stderr)
+                return False
+    try:
+        ready, message = ensure_fn()
+    except Exception as e:  # never let the diagram step break setup
+        print(f"  [WARN] Graphviz install attempt failed: {e}", file=sys.stderr)
+        print("  Diagram tools will stay disabled until Graphviz is installed.", file=sys.stderr)
+        return False
+    tag = "[OK]" if ready else "[WARN]"
+    print(f"  {tag} {message}", file=sys.stderr)
+    if not ready:
+        print("  Diagram tools will stay disabled until Graphviz is installed.", file=sys.stderr)
+    return ready
+
+
 def setup_command(args):
     """
     One-command setup: installs PyTorch, downloads all sources, and builds index
@@ -558,6 +587,9 @@ def setup_command(args):
         print("\n[OK] Index built successfully", file=sys.stderr)
     else:
         print("\n[OK] Index already exists (use --rebuild to force rebuild)", file=sys.stderr)
+
+    # Diagram tools: provision system Graphviz (best effort, never blocks setup)
+    _setup_graphviz()
 
     # Setup BigQuery authentication (auto-detect in non-interactive, prompt in interactive)
     if not getattr(args, "non_interactive", False):

--- a/mcp_server/tools/patent_law_tools.py
+++ b/mcp_server/tools/patent_law_tools.py
@@ -104,8 +104,28 @@ def register_patent_law_tools(
                             r["jurisdiction"] = jurisdiction
                         all_results.extend(results)
                     except Exception:
-                        # Source may not be indexed yet — skip silently
+                        # Source not indexed; reported below if the whole
+                        # jurisdiction comes up empty.
                         pass
+
+                if not all_results:
+                    # An empty result here means the jurisdiction's corpus is
+                    # absent (vector search over an indexed source always
+                    # returns nearest neighbours) — say so instead of
+                    # returning [] that reads as "no relevant law exists".
+                    return [
+                        {
+                            "error": (
+                                f"No {jurisdiction} patent-law sources are "
+                                f"installed or indexed (looked for: "
+                                f"{', '.join(source_filters)}). The default "
+                                f"setup downloads US sources only. Re-run "
+                                f"'patent-creator setup' after adding the "
+                                f"{jurisdiction} sources, or search with "
+                                f"jurisdiction='US'."
+                            )
+                        }
+                    ]
 
                 # Sort by relevance and limit. mpep_index.search() returns the
                 # rerank score under "relevance_score" — keying on "score" made

--- a/tests/test_patent_law_tools.py
+++ b/tests/test_patent_law_tools.py
@@ -69,3 +69,49 @@ def test_unknown_jurisdiction_is_rejected():
     search_patent_law = _make_tool()
     results = search_patent_law(query="x", jurisdiction="ZZ", top_k=5)
     assert len(results) == 1 and "error" in results[0]
+
+
+class _USOnlyIndex(_FakeIndex):
+    """Simulates a fresh install: US sources indexed, EPO/PCT absent."""
+
+    def search(self, query, top_k, source_filter=None):
+        if source_filter not in self.SCORES:
+            raise KeyError(f"source not indexed: {source_filter}")
+        return super().search(query, top_k, source_filter=source_filter)
+
+
+def _make_us_only_tool():
+    mcp = _FakeMCP()
+    patent_law_tools.register_patent_law_tools(
+        mcp,
+        mpep_index=_USOnlyIndex(),
+        log_info=lambda *a, **k: None,
+        log_error=lambda *a, **k: None,
+        validate_input=None,
+        SearchPatentLawInput=None,
+        track_performance=lambda *a, **k: (lambda f: f),
+    )
+    return mcp.tools["search_patent_law"]
+
+
+def test_missing_jurisdiction_sources_reported_not_silent():
+    """A fresh install has no EPO/PCT corpus; the tool must say so instead of
+    returning an empty list that reads as 'no relevant law exists'."""
+    search_patent_law = _make_us_only_tool()
+
+    results = search_patent_law(query="inventive step", jurisdiction="EPO", top_k=5)
+
+    assert len(results) == 1
+    error = results[0]["error"]
+    # Must explain the absence and point at a remedy, naming the jurisdiction.
+    assert "EPO" in error
+    assert "installed" in error or "indexed" in error
+    assert "setup" in error.lower()
+
+
+def test_us_results_unaffected_by_missing_epo_sources():
+    search_patent_law = _make_us_only_tool()
+
+    results = search_patent_law(query="definiteness", jurisdiction="US", top_k=3)
+
+    assert results and all("error" not in r for r in results)

--- a/tests/test_setup_graphviz_step.py
+++ b/tests/test_setup_graphviz_step.py
@@ -1,0 +1,34 @@
+"""setup must attempt to provision system Graphviz.
+
+A fresh install shipped with all four diagram tools dead: the Python
+graphviz package was present but the system binary was not, and setup never
+ran the installer the repo already ships (graphviz_installer.ensure_graphviz).
+The step is best-effort: failure prints guidance and never blocks setup.
+"""
+
+from mcp_server import cli
+
+
+def test_setup_graphviz_reports_success():
+    ready = cli._setup_graphviz(ensure_fn=lambda: (True, "Graphviz 14.1.2 ready"))
+    assert ready is True
+
+
+def test_setup_graphviz_failure_is_nonfatal():
+    ready = cli._setup_graphviz(ensure_fn=lambda: (False, "no package manager found"))
+    assert ready is False
+
+
+def test_setup_graphviz_survives_installer_crash():
+    def boom():
+        raise RuntimeError("installer exploded")
+
+    ready = cli._setup_graphviz(ensure_fn=boom)
+    assert ready is False
+
+
+def test_setup_command_wires_graphviz_step():
+    """The step must actually be reachable from setup_command."""
+    import inspect
+
+    assert "_setup_graphviz(" in inspect.getsource(cli.setup_command)


### PR DESCRIPTION
Two fresh-install gaps found by running the product end-to-end as a new
user:

- All four diagram tools were dead out of the box: the Python graphviz
  package installs with the wheel, but the system binary does not, and
  setup never invoked the installer the repo already ships. setup now runs
  graphviz_installer.ensure_graphviz() as a best-effort step — success
  enables the diagram tools, failure prints guidance and never blocks the
  rest of setup.

- search_patent_law advertises US/EPO/PCT coverage but the default setup
  only downloads US sources, and a jurisdiction-filtered search over an
  absent corpus returned a bare [] that reads as 'no relevant law exists'.
  It now returns an explicit error naming the missing sources and the
  remedy. (Wiring EPO/PCT corpus downloads into setup is tracked
  separately — this fixes the silent lie, not the missing feature.)
