### PR TITLE
fix: run setup non-interactively when stdin is not a TTY

### DIFF
--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -455,6 +455,28 @@ def setup_bigquery_auth_prompt():
     return False
 
 
+def _stdin_is_interactive() -> bool:
+    """True when stdin can answer input() prompts."""
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except Exception:
+        return False
+
+
+def _normalize_interactivity(args) -> None:
+    """Force non-interactive mode when stdin cannot answer prompts.
+
+    Without this, setup's input() calls raise EOFError in CI, agent-driven,
+    or piped contexts (issue #52). An explicit --non-interactive always wins.
+    """
+    if not getattr(args, "non_interactive", False) and not _stdin_is_interactive():
+        args.non_interactive = True
+        print(
+            "[INFO] stdin is not a terminal -- running setup non-interactively",
+            file=sys.stderr,
+        )
+
+
 def _setup_graphviz(ensure_fn=None) -> bool:
     """Provision system Graphviz so the diagram tools work out of the box.
 
@@ -496,6 +518,8 @@ def setup_command(args):
     print("\n" + "=" * 60, file=sys.stderr)
     print("Claude Patent Creator - Automatic Setup", file=sys.stderr)
     print("=" * 60, file=sys.stderr)
+
+    _normalize_interactivity(args)
 
     # Step 1: Install PyTorch with hardware detection
     print("\n[1/4] Checking PyTorch installation...", file=sys.stderr)

--- a/tests/test_setup_non_tty.py
+++ b/tests/test_setup_non_tty.py
@@ -1,0 +1,47 @@
+"""setup must not crash when stdin is not a TTY (issue #52).
+
+setup_bigquery_auth_prompt() calls input(); in CI, agent-driven, or piped
+contexts with no usable stdin that raises EOFError mid-setup. When stdin is
+not interactive, setup must fall back to its existing --non-interactive path.
+"""
+
+from types import SimpleNamespace
+
+from mcp_server import cli
+
+
+def _args(non_interactive=False):
+    return SimpleNamespace(non_interactive=non_interactive, rebuild=False, no_hyde=False)
+
+
+def test_non_tty_stdin_forces_non_interactive(monkeypatch):
+    monkeypatch.setattr(cli, "_stdin_is_interactive", lambda: False)
+    args = _args()
+
+    cli._normalize_interactivity(args)
+
+    assert args.non_interactive is True
+
+
+def test_tty_stdin_keeps_interactive(monkeypatch):
+    monkeypatch.setattr(cli, "_stdin_is_interactive", lambda: True)
+    args = _args()
+
+    cli._normalize_interactivity(args)
+
+    assert args.non_interactive is False
+
+
+def test_explicit_flag_is_never_downgraded(monkeypatch):
+    monkeypatch.setattr(cli, "_stdin_is_interactive", lambda: True)
+    args = _args(non_interactive=True)
+
+    cli._normalize_interactivity(args)
+
+    assert args.non_interactive is True
+
+
+def test_setup_command_wires_normalization():
+    import inspect
+
+    assert "_normalize_interactivity(" in inspect.getsource(cli.setup_command)


### PR DESCRIPTION
setup_bigquery_auth_prompt() calls input(), which raises EOFError in CI,
agent-driven, or piped contexts with no usable stdin, crashing setup
mid-run. setup now detects a non-interactive stdin up front and falls back
to the existing --non-interactive path (auto-detecting gcloud auth instead
of prompting). An explicit --non-interactive flag is unaffected.

Closes #52
