### PR TITLE
fix: store corpora and search index outside site-packages

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -92,3 +92,10 @@ $env:VARIABLE_NAME
   expensive query or appearing to hang. To run a larger search, raise the ceiling (e.g.
   `536870912000` for ~500 GiB) or narrow the search with `country` / `start_year` /
   `end_year` filters or more specific keywords.
+- `PATENT_DATA_DIR` - Where downloaded corpora (MPEP/USC/CFR PDFs, ~500 MB) and the search
+  index (~150 MB) are stored. Default: the platform app-data directory
+  (`%APPDATA%\claude-patent-creator\data` on Windows, `~/.local/share/claude-patent-creator/data`
+  elsewhere), so the data survives reinstalls and upgrades. Installs that already hold data at
+  the legacy in-package location keep using it — no migration needed. Changing this setting
+  does not move existing data; re-run `patent-creator setup` to download and rebuild at the
+  new location.

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -133,6 +133,15 @@ OPTIONS: tuple[Option, ...] = (
         "choice", default="INFO",
         choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
     ),
+    Option(
+        "PATENT_DATA_DIR", "Performance", "Data directory",
+        "Where downloaded corpora (MPEP/USC/CFR PDFs) and the search index "
+        "are stored. Empty = platform app-data dir, or the legacy in-tree "
+        "location when it already holds data.",
+        "str",
+        note="Changing this does not move existing data; re-run "
+        "'patent-creator setup' to download and rebuild at the new location.",
+    ),
 )
 
 OPTIONS_BY_KEY: dict[str, Option] = {o.key: o for o in OPTIONS}

--- a/mcp_server/data_paths.py
+++ b/mcp_server/data_paths.py
@@ -1,0 +1,64 @@
+"""Where downloaded corpora and the search index live on disk (issue #51).
+
+These used to be derived from ``Path(__file__)``, i.e. inside the installed
+package, where a reinstall or venv removal silently destroys ~650 MB of
+downloads plus a 5-15 minute index build.
+
+Resolution order for each directory:
+
+1. ``PATENT_DATA_DIR`` environment variable (also settable via
+   ``patent-creator config set PATENT_DATA_DIR ...`` — the config layer
+   bridges file values into the environment at server startup).
+2. The legacy in-tree location, only when it already contains data — so
+   installs that predate this module keep using what they downloaded, with
+   no migration step.
+3. The platform app-data directory, which survives pip upgrades and
+   reinstalls.
+"""
+
+import os
+from pathlib import Path
+
+_PACKAGE_DIR = Path(__file__).parent
+
+# Legacy in-tree locations (pre-#51). Module-level so tests can repoint them.
+LEGACY_PDFS_DIR = _PACKAGE_DIR.parent / "pdfs"
+LEGACY_INDEX_DIR = _PACKAGE_DIR / "index"
+LEGACY_DIAGRAMS_DIR = _PACKAGE_DIR.parent / "diagrams"
+
+_APP_DIR_NAME = "claude-patent-creator"
+
+
+def _default_base() -> Path:
+    if os.name == "nt":
+        base = os.environ.get("APPDATA") or str(Path.home())
+        return Path(base) / _APP_DIR_NAME / "data"
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(base) / _APP_DIR_NAME / "data"
+
+
+def _resolve(name: str, legacy: Path, has_data) -> Path:
+    override = os.environ.get("PATENT_DATA_DIR")
+    if override:
+        return Path(override) / name
+    try:
+        if has_data(legacy):
+            return legacy
+    except OSError:
+        pass
+    return _default_base() / name
+
+
+def mpep_dir() -> Path:
+    """Directory holding MPEP/USC/CFR source PDFs and text."""
+    return _resolve("pdfs", LEGACY_PDFS_DIR, lambda p: any(p.glob("*.pdf")))
+
+
+def index_dir() -> Path:
+    """Directory holding the FAISS index and chunk store."""
+    return _resolve("index", LEGACY_INDEX_DIR, lambda p: (p / "mpep_index.faiss").exists())
+
+
+def diagrams_dir() -> Path:
+    """Default output directory for generated diagrams."""
+    return _resolve("diagrams", LEGACY_DIAGRAMS_DIR, lambda p: p.is_dir() and any(p.iterdir()))

--- a/mcp_server/diagram_generator.py
+++ b/mcp_server/diagram_generator.py
@@ -23,9 +23,15 @@ except ImportError:
     GraphvizInstaller = None
 
 
-# Default output directory for generated diagrams (created lazily in __init__, not at import time)
+# Default output directory for generated diagrams (created lazily in __init__,
+# not at import time) — resolved outside site-packages (see data_paths / #51).
+try:
+    from data_paths import diagrams_dir
+except ImportError:
+    from mcp_server.data_paths import diagrams_dir
+
 PROJECT_ROOT = Path(__file__).parent.parent
-DIAGRAMS_DIR = PROJECT_ROOT / "diagrams"
+DIAGRAMS_DIR = diagrams_dir()
 
 
 class PatentDiagramGenerator:

--- a/mcp_server/health_check.py
+++ b/mcp_server/health_check.py
@@ -21,9 +21,14 @@ except ImportError:
 try:
     from server import INDEX_DIR, MPEP_DIR
 except ImportError:
-    # Fallback for standalone testing
-    INDEX_DIR = Path(__file__).parent / "index"
-    MPEP_DIR = Path(__file__).parent.parent / "pdfs"
+    # Fallback for standalone testing — same resolution as the server
+    try:
+        from data_paths import index_dir, mpep_dir
+    except ImportError:
+        from mcp_server.data_paths import index_dir, mpep_dir
+
+    INDEX_DIR = index_dir()
+    MPEP_DIR = mpep_dir()
 
 
 class SystemHealthChecker:

--- a/mcp_server/mpep_search.py
+++ b/mcp_server/mpep_search.py
@@ -85,9 +85,15 @@ except ImportError:
     LOGGING_AVAILABLE = False
 
 
-# Global variables for the RAG system
-MPEP_DIR = Path(__file__).parent.parent / "pdfs"
-INDEX_DIR = Path(__file__).parent / "index"
+# Global variables for the RAG system — resolved outside site-packages so a
+# reinstall cannot destroy downloads or the index (see data_paths / issue #51).
+try:
+    from data_paths import index_dir, mpep_dir
+except ImportError:
+    from mcp_server.data_paths import index_dir, mpep_dir
+
+MPEP_DIR = mpep_dir()
+INDEX_DIR = index_dir()
 
 # Ensure directories exist
 MPEP_DIR.mkdir(parents=True, exist_ok=True)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -88,9 +88,15 @@ mcp = FastMCP("claude-patent-creator")
 # Initialize logger
 logger = get_logger()
 
-# Global variables
-MPEP_DIR = Path(__file__).parent.parent / "pdfs"
-INDEX_DIR = Path(__file__).parent / "index"
+# Global variables — resolved outside site-packages so a reinstall cannot
+# destroy downloads or the index (see data_paths / issue #51).
+try:
+    from data_paths import index_dir, mpep_dir
+except ImportError:
+    from mcp_server.data_paths import index_dir, mpep_dir
+
+MPEP_DIR = mpep_dir()
+INDEX_DIR = index_dir()
 mpep_index: Any = None
 
 # Ensure directories exist

--- a/tests/test_data_paths.py
+++ b/tests/test_data_paths.py
@@ -1,0 +1,62 @@
+"""Downloaded corpora and the search index must not live in site-packages.
+
+Issue #51: ~650 MB of PDFs plus a 5-15 minute index build lived at paths
+derived from Path(__file__), i.e. inside the installed package, where a
+reinstall or venv removal silently destroys them. data_paths resolves each
+data directory as: PATENT_DATA_DIR override > legacy in-tree location when
+it already holds data (existing installs keep working) > platform app-data.
+"""
+
+import pytest
+
+from mcp_server import data_paths
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("PATENT_DATA_DIR", raising=False)
+    # Point the legacy locations at empty temp dirs so the machine running
+    # the tests (which may have a real install) does not leak into them.
+    monkeypatch.setattr(data_paths, "LEGACY_PDFS_DIR", tmp_path / "legacy_pdfs")
+    monkeypatch.setattr(data_paths, "LEGACY_INDEX_DIR", tmp_path / "legacy_index")
+    monkeypatch.setattr(data_paths, "LEGACY_DIAGRAMS_DIR", tmp_path / "legacy_diagrams")
+
+
+def test_override_wins(monkeypatch, tmp_path):
+    override = tmp_path / "mydata"
+    monkeypatch.setenv("PATENT_DATA_DIR", str(override))
+
+    assert data_paths.mpep_dir() == override / "pdfs"
+    assert data_paths.index_dir() == override / "index"
+    assert data_paths.diagrams_dir() == override / "diagrams"
+
+
+def test_legacy_location_with_data_is_kept(monkeypatch, tmp_path):
+    """An install that already downloaded everything keeps using it."""
+    legacy_pdfs = tmp_path / "legacy_pdfs"
+    legacy_pdfs.mkdir()
+    (legacy_pdfs / "mpep-0100.pdf").write_bytes(b"x")
+    legacy_index = tmp_path / "legacy_index"
+    legacy_index.mkdir()
+    (legacy_index / "mpep_index.faiss").write_bytes(b"x")
+
+    assert data_paths.mpep_dir() == legacy_pdfs
+    assert data_paths.index_dir() == legacy_index
+
+
+def test_fresh_install_defaults_outside_site_packages(monkeypatch, tmp_path):
+    """No override, no legacy data -> platform app-data, never the package."""
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    for resolved in (data_paths.mpep_dir(), data_paths.index_dir()):
+        assert data_paths._PACKAGE_DIR not in resolved.parents
+        assert resolved != data_paths._PACKAGE_DIR
+        assert "claude-patent-creator" in str(resolved)
+
+
+def test_empty_legacy_dir_does_not_count_as_data(tmp_path):
+    """A leftover empty directory must not pin data to site-packages."""
+    (tmp_path / "legacy_pdfs").mkdir()
+
+    assert data_paths.mpep_dir() != tmp_path / "legacy_pdfs"


### PR DESCRIPTION
MPEP/USC/CFR PDFs (~500 MB) and the FAISS index (~150 MB) lived at paths
derived from Path(__file__) — inside the installed package — so a
reinstall, forced upgrade, or venv removal silently destroyed the
downloads plus a 5-15 minute index build.

New mcp_server/data_paths.py resolves each data directory as:

1. PATENT_DATA_DIR (env var, or config file via the config layer — added
   to the schema so 'patent-creator config set PATENT_DATA_DIR' works)
2. the legacy in-tree location, only when it already holds data, so
   existing installs keep working with no migration
3. the platform app-data directory (APPDATA / XDG_DATA_HOME), which
   survives pip operations

mpep_search, server, health_check, and diagram_generator now resolve
through it; docs updated.

Closes #51
