### PR TITLE
fix: stop google.auth from shelling out to gcloud inside the MCP server

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -84,6 +84,11 @@ class BigQueryBudgetExceededError(ValueError):
     working, while paths that must not swallow it can re-raise by type."""
 
 
+class BigQueryQuotaExhaustedError(ValueError):
+    """Raised when BigQuery rejects a query because the project's monthly
+    free-tier bytes are exhausted (sandbox projects with no billing account)."""
+
+
 class BigQueryPatentSearch:
     """
     Search patents using Google BigQuery Patents Public Data
@@ -169,6 +174,15 @@ class BigQueryPatentSearch:
                 f"No Google Cloud project ID found.\n{setup_msg}"
             )
 
+        # Tell google.auth what we already resolved. Without this, its default
+        # credential chain re-derives the project id by running a
+        # `gcloud config config-helper` subprocess — which blocks indefinitely
+        # inside an MCP stdio server (no console; stdin/stdout are the JSON-RPC
+        # pipes), presenting to users as a multi-minute search stall.
+        self._prepare_auth_environment(
+            self.billing_project, _get_gcloud_credentials_path()
+        )
+
         try:
             self.client = bigquery.Client(project=self.billing_project)  # type: ignore[union-attr]
 
@@ -180,6 +194,27 @@ class BigQueryPatentSearch:
             raise ValueError(
                 f"Could not initialize BigQuery client: {e}\n{setup_msg}"
             ) from e
+
+    @staticmethod
+    def _prepare_auth_environment(billing_project, creds_path) -> None:
+        """Export resolved auth facts so google.auth never shells out.
+
+        google.auth.default() falls back to a `gcloud config config-helper`
+        subprocess when it cannot determine credentials/project from the
+        environment. That subprocess hangs in console-less MCP server
+        processes. Setting GOOGLE_CLOUD_PROJECT and (when the ADC file
+        exists) GOOGLE_APPLICATION_CREDENTIALS makes the explicit-environment
+        paths win, so the subprocess fallback is unreachable. User-set values
+        are never overridden.
+        """
+        if billing_project and not os.environ.get("GOOGLE_CLOUD_PROJECT"):
+            os.environ["GOOGLE_CLOUD_PROJECT"] = str(billing_project)
+        if (
+            creds_path is not None
+            and not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            and Path(creds_path).exists()
+        ):
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(creds_path)
 
     def check_availability(self) -> dict[str, Any]:
         """
@@ -973,6 +1008,15 @@ class BigQueryPatentSearch:
         text = str(exc)
         return "bytesBilledLimitExceeded" in text or "limit for bytes billed" in text.lower()
 
+    @staticmethod
+    def _is_free_tier_quota_rejection(exc: Exception) -> bool:
+        """Recognize the sandbox 'free query bytes scanned' quota rejection."""
+        for err in getattr(exc, "errors", None) or []:
+            if isinstance(err, dict) and err.get("reason") == "quotaExceeded":
+                return True
+        text = str(exc)
+        return "quotaExceeded" in text or "free query bytes" in text.lower()
+
     def _run_query(self, sql: str, parameters: list, narrowing_hint: str = "") -> Any:
         """Pre-flight the cost, then execute the query and return the row iterator.
 
@@ -996,6 +1040,17 @@ class BigQueryPatentSearch:
             except BigQueryBudgetExceededError:
                 raise
             except Exception as e:
+                if self._is_free_tier_quota_rejection(e):
+                    raise BigQueryQuotaExhaustedError(
+                        "BigQuery's monthly free tier for this project is used up "
+                        "(sandbox projects get 1 TiB of query scanning per month; "
+                        "a default patent search scans ~325 GiB, so about 3 free "
+                        "searches). Options: wait for the quota reset on the 1st "
+                        "of the month, attach a billing account to the project in "
+                        "the Google Cloud console (~$2 per default search after "
+                        "the free tier), or use narrower search_fields to cut the "
+                        "per-search scan."
+                    ) from e
                 if self._is_bytes_billed_rejection(e):
                     raise self._budget_error(None, max_bytes, narrowing_hint) from e
                 raise

--- a/tests/test_bigquery_auth_env.py
+++ b/tests/test_bigquery_auth_env.py
@@ -1,0 +1,85 @@
+"""BigQuery client creation must never shell out to gcloud (the MCP hang).
+
+Root cause of the "search stalls" bug: google.auth.default() falls back to
+running `gcloud config config-helper` in a subprocess to discover a project
+id the code already resolved. Inside an MCP stdio server (no console, pipes
+for stdin/stdout) that child process blocks indefinitely — users see a
+multi-minute stall or a dead server. Verified by faulthandler stack dump:
+AnyIO worker thread stuck in google/auth/_cloud_sdk.py get_project_id →
+subprocess communicate().
+
+Fix under test: before creating the client, export what we already know
+(GOOGLE_CLOUD_PROJECT, GOOGLE_APPLICATION_CREDENTIALS) so google.auth's
+explicit-environment paths win and the subprocess fallback is unreachable.
+"""
+
+import pytest
+
+from mcp_server.bigquery_search import (
+    BigQueryPatentSearch,
+    BigQueryQuotaExhaustedError,
+)
+from tests.test_bigquery_budget import _searcher
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.setenv("PATENT_CONFIG_DIR", str(tmp_path))
+
+
+def test_exports_resolved_project_when_absent(monkeypatch):
+    import os
+
+    BigQueryPatentSearch._prepare_auth_environment("my-project", None)
+
+    assert os.environ["GOOGLE_CLOUD_PROJECT"] == "my-project"
+
+
+def test_never_overrides_existing_project(monkeypatch):
+    import os
+
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "user-set")
+    BigQueryPatentSearch._prepare_auth_environment("resolved-other", None)
+
+    assert os.environ["GOOGLE_CLOUD_PROJECT"] == "user-set"
+
+
+def test_exports_adc_path_when_file_exists(monkeypatch, tmp_path):
+    import os
+
+    creds = tmp_path / "application_default_credentials.json"
+    creds.write_text("{}")
+
+    BigQueryPatentSearch._prepare_auth_environment("p", creds)
+
+    assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(creds)
+
+
+def test_no_adc_export_when_file_missing(monkeypatch, tmp_path):
+    import os
+
+    BigQueryPatentSearch._prepare_auth_environment("p", tmp_path / "does_not_exist.json")
+
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
+
+
+def test_free_tier_quota_error_is_actionable():
+    """The sandbox's monthly free bytes run out after ~3 default searches;
+    the raw 403 must become guidance, like the budget guard's errors."""
+    searcher = _searcher(
+        dry_estimate=1,
+        result_side_effect=Exception(
+            "403 Quota exceeded: Your project exceeded quota for free query "
+            "bytes scanned. reason: quotaExceeded, location: unbilled.analysis"
+        ),
+    )
+
+    with pytest.raises(BigQueryQuotaExhaustedError) as exc:
+        searcher._run_query("SELECT 1", [])
+
+    msg = str(exc.value)
+    assert "free" in msg.lower()
+    assert "billing" in msg.lower()
+    assert "1st" in msg or "month" in msg.lower()

--- a/tests/test_bigquery_auth_env.py
+++ b/tests/test_bigquery_auth_env.py
@@ -13,13 +13,29 @@ Fix under test: before creating the client, export what we already know
 explicit-environment paths win and the subprocess fallback is unreachable.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from mcp_server.bigquery_search import (
     BigQueryPatentSearch,
     BigQueryQuotaExhaustedError,
 )
-from tests.test_bigquery_budget import _searcher
+
+
+def _searcher(dry_estimate=None, result_side_effect=None):
+    """Minimal mocked-client searcher (kept local: tests/ is not a package,
+    so cross-module test imports break under CI's import mode)."""
+    searcher = object.__new__(BigQueryPatentSearch)
+    client = MagicMock()
+    job = client.query.return_value
+    job.total_bytes_processed = dry_estimate
+    if result_side_effect is not None:
+        job.result.side_effect = result_side_effect
+    else:
+        job.result.return_value = iter([])
+    searcher.client = client
+    return searcher
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Searches appeared to stall (multi-minute hangs, dead server connections)
whenever the MCP server had to create its BigQuery client. Faulthandler
stack dumps pinned the hang: google.auth.default() falls back to running a
'gcloud config config-helper' subprocess to discover a project id — and
inside an MCP stdio server (no console; stdin/stdout are the JSON-RPC
pipes) that child process blocks indefinitely. A terminal run of the same
code initializes in under a second, which is why the bug only ever bit
real users mid-session.

BigQueryPatentSearch already resolves the billing project and locates the
ADC file itself; it just never told google.auth. __init__ now exports
GOOGLE_CLOUD_PROJECT and (when the ADC file exists)
GOOGLE_APPLICATION_CREDENTIALS before creating the client, so the
explicit-environment credential paths win and the subprocess fallback is
unreachable. User-set values are never overridden.

Also translate the sandbox free-tier rejection (403 quotaExceeded on 'free
query bytes scanned') into an actionable BigQueryQuotaExhaustedError: the
1 TiB/month sandbox allows ~3 default searches, and users previously got a
raw 403 with no explanation of the reset date, billing option, or
narrower-fields alternative.
