### PR TITLE
fix: load ADC credentials explicitly so google.auth.default() never runs

### DIFF
--- a/mcp_server/bigquery_search.py
+++ b/mcp_server/bigquery_search.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 
 try:
     from google.api_core.exceptions import NotFound
+    from google.auth import load_credentials_from_file as _load_creds_from_file
     from google.cloud import bigquery
     from google.cloud.exceptions import GoogleCloudError
 
@@ -23,6 +24,7 @@ except ImportError:
     bigquery = None
     GoogleCloudError = Exception
     NotFound = Exception
+    _load_creds_from_file = None
 
 # Import logging and monitoring with fallback
 try:
@@ -184,7 +186,17 @@ class BigQueryPatentSearch:
         )
 
         try:
-            self.client = bigquery.Client(project=self.billing_project)  # type: ignore[union-attr]
+            # Explicit credentials keep google.auth.default() from ever
+            # running: its chain special-cases the well-known ADC path back
+            # into the gcloud-SDK handler, whose `gcloud config config-helper`
+            # subprocess hangs in console-less MCP servers. With credentials
+            # passed, the client never consults default() at all.
+            credentials = self._load_explicit_credentials(
+                _get_gcloud_credentials_path(), self.billing_project
+            )
+            self.client = bigquery.Client(  # type: ignore[union-attr]
+                project=self.billing_project, credentials=credentials
+            )
 
             if LOGGING_AVAILABLE and logger:
                 logger.info(
@@ -194,6 +206,29 @@ class BigQueryPatentSearch:
             raise ValueError(
                 f"Could not initialize BigQuery client: {e}\n{setup_msg}"
             ) from e
+
+    @staticmethod
+    def _load_explicit_credentials(creds_path, quota_project):
+        """Load ADC credentials directly from the well-known file.
+
+        Returns None (letting the client fall back to google.auth.default())
+        only when the file is absent or unreadable. Passing explicit
+        credentials to the client is the load-bearing part of the MCP-hang
+        fix: default()'s chain runs a gcloud subprocess for project discovery
+        even when GOOGLE_APPLICATION_CREDENTIALS is set, because the
+        well-known ADC path is special-cased back into the gcloud handler.
+        """
+        if _load_creds_from_file is None or creds_path is None:
+            return None
+        try:
+            if not Path(creds_path).exists():
+                return None
+            credentials, _project = _load_creds_from_file(
+                str(creds_path), quota_project_id=quota_project
+            )
+            return credentials
+        except Exception:
+            return None
 
     @staticmethod
     def _prepare_auth_environment(billing_project, creds_path) -> None:

--- a/tests/test_bigquery_auth_env.py
+++ b/tests/test_bigquery_auth_env.py
@@ -99,3 +99,43 @@ def test_free_tier_quota_error_is_actionable():
     assert "free" in msg.lower()
     assert "billing" in msg.lower()
     assert "1st" in msg or "month" in msg.lower()
+
+
+def test_explicit_credentials_bypass_default_chain(monkeypatch, tmp_path):
+    """Pointing GOOGLE_APPLICATION_CREDENTIALS at the gcloud well-known path
+    routes google.auth.default() straight back into the gcloud-SDK handler
+    and its config-helper subprocess (verified by stack dump). The client
+    must therefore receive explicitly loaded credentials so default() never
+    runs."""
+    from mcp_server import bigquery_search as bs
+
+    creds_file = tmp_path / "application_default_credentials.json"
+    creds_file.write_text("{}")
+    sentinel = object()
+    monkeypatch.setattr(
+        bs, "_load_creds_from_file", lambda path, quota_project_id=None: (sentinel, None)
+    )
+
+    loaded = BigQueryPatentSearch._load_explicit_credentials(creds_file, "proj")
+
+    assert loaded is sentinel
+
+
+def test_explicit_credentials_none_when_file_missing(tmp_path):
+    loaded = BigQueryPatentSearch._load_explicit_credentials(tmp_path / "missing.json", "proj")
+
+    assert loaded is None
+
+
+def test_explicit_credentials_none_on_load_failure(monkeypatch, tmp_path):
+    from mcp_server import bigquery_search as bs
+
+    creds_file = tmp_path / "application_default_credentials.json"
+    creds_file.write_text("{}")
+
+    def boom(path, quota_project_id=None):
+        raise ValueError("bad file")
+
+    monkeypatch.setattr(bs, "_load_creds_from_file", boom)
+
+    assert BigQueryPatentSearch._load_explicit_credentials(creds_file, "proj") is None


### PR DESCRIPTION
The previous fix (exporting GOOGLE_APPLICATION_CREDENTIALS) was not
sufficient: google.auth special-cases the well-known ADC path back into
its gcloud-SDK handler (_default.py _get_explicit_environ_credentials ->
_get_gcloud_sdk_credentials), which still runs the config-helper
subprocess that hangs in console-less MCP servers — verified by a second
faulthandler stack dump.

Credentials are now loaded directly from the ADC file
(google.auth.load_credentials_from_file, quota project attached) and
passed to bigquery.Client, so the default() chain — and with it the
subprocess — never executes. Falls back to default() only when the file
is absent or unreadable.

E2E verified in the failing environment: a limit-15 MCP search that
previously hung 240s+ now completes in ~22s including server start,
returning the actionable quota message.
