### PR TITLE
fix: actually bridge config into the MCP server env; keep checks_skipped across the tool boundary

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -627,6 +627,24 @@ def _run_health_checks():
 
 def main():
     """Main entry point"""
+    # Bridge config-file settings into the environment before anything reads
+    # os.environ. The config layer documents this as happening at server
+    # startup; until now nothing actually called it, so file-configured
+    # settings (GOOGLE_CLOUD_PROJECT, PATENT_ENABLE_ANTECEDENT_CHECK, ...)
+    # never reached the MCP server process.
+    try:
+        from config import apply_config_to_env
+    except ImportError:
+        try:
+            from mcp_server.config import apply_config_to_env
+        except ImportError:
+            apply_config_to_env = None
+    if apply_config_to_env is not None:
+        try:
+            apply_config_to_env()
+        except Exception as e:
+            _log_warning(f"config bridge failed: {e}")
+
     args = _parse_args()
 
     # Handle download requests

--- a/mcp_server/tools/analyzer_tools.py
+++ b/mcp_server/tools/analyzer_tools.py
@@ -96,6 +96,9 @@ def register_analyzer_tools(
                     "important_issues": analysis_results["important_issues"],
                     "minor_issues": analysis_results["minor_issues"],
                     "issues_by_type": analysis_results["issues_by_type"],
+                    # Skipped-check disclosure must survive the MCP boundary;
+                    # dropping it here silently undid the report's honesty.
+                    "checks_skipped": analysis_results.get("checks_skipped", []),
                     "summary": analysis_results["summary"],
                     "issues": analysis_results["issues"],
                     "mpep_references": mpep_refs,

--- a/tests/test_config_bridge_and_report.py
+++ b/tests/test_config_bridge_and_report.py
@@ -1,0 +1,34 @@
+"""Two gaps found by driving the MCP server for real (patent campaign):
+
+1. config.apply_config_to_env() was documented as running at server startup
+   but nothing ever called it -- config-file settings (GOOGLE_CLOUD_PROJECT,
+   PATENT_ENABLE_ANTECEDENT_CHECK, ...) never reached the MCP server.
+2. The analyzer tool layer rebuilds the claims report field-by-field and
+   silently dropped checks_skipped, undoing the honesty guarantee of #47 at
+   the MCP boundary.
+
+server.py uses flat imports and cannot be imported as a package module in
+tests, so those assertions read source text.
+"""
+
+from pathlib import Path
+
+MCP_SERVER_DIR = Path(__file__).parent.parent / "mcp_server"
+
+
+def test_server_main_bridges_config_into_environment():
+    src = (MCP_SERVER_DIR / "server.py").read_text(encoding="utf-8")
+    main_body = src.split("def main():", 1)[1]
+    assert "apply_config_to_env(" in main_body
+
+
+def test_analyzer_tool_passes_checks_skipped_through():
+    src = (MCP_SERVER_DIR / "tools" / "analyzer_tools.py").read_text(encoding="utf-8")
+    assert "checks_skipped" in src
+
+
+def test_claims_analyzer_report_still_provides_checks_skipped():
+    from mcp_server.claims_analyzer import ClaimsAnalyzer
+
+    report = ClaimsAnalyzer().analyze_claims("1. An apparatus comprising: a widget.")
+    assert "checks_skipped" in report


### PR DESCRIPTION
Two gaps found by driving the server in production:

- config.apply_config_to_env() was documented as running at server startup
  but nothing ever called it, so config-file settings (GOOGLE_CLOUD_PROJECT,
  PATENT_ENABLE_ANTECEDENT_CHECK, PATENT_DATA_DIR, ...) never reached the
  MCP server process. server.main() now bridges before anything reads
  os.environ.

- review_patent_claims rebuilt the analyzer report field-by-field and
  silently dropped checks_skipped, undoing the skipped-check disclosure at
  the MCP boundary. The field now passes through.
