### PR TITLE
feat: check_package — deterministic whole-package consistency gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ patent-creator check-bigquery    # Test BigQuery connection
 | `review_patent_claims` | 35 USC 112(b) compliance check (definiteness, antecedent basis, structure) |
 | `review_specification` | 35 USC 112(a) adequacy check (written description, enablement, best mode) |
 | `check_formalities` | MPEP 608 compliance (abstract, title, drawings, required sections) |
+| `check_package` | Whole-package consistency: stale verification stamps, claim-count disagreements, status contradictions, commentary inside filing copies, date errors |
 
 ### Generation
 

--- a/mcp_server/package_checker.py
+++ b/mcp_server/package_checker.py
@@ -1,0 +1,386 @@
+"""Package-level consistency checker for assembled filing packages.
+
+Per-artifact checkers (review_patent_claims, review_specification,
+check_formalities) each validate one document in isolation. Nothing
+validated the PACKAGE — so a README could claim "verified" beside a stale
+draft header, a claim could be added after its recorded compliance check,
+and strategy commentary could ride along inside documents marked for
+filing. This module checks the assembly:
+
+- verification-stamp freshness: a stamp is a backticked lowercase-hex
+  prefix of the SHA-256 of the target file's raw bytes, written near the
+  word "hash". Stamps are recomputed; a mismatch means edit-after-check.
+  A stamp whose target file cannot be resolved is unverifiable, which is
+  treated as unverified.
+- claim-count agreement between the claims file and every "N claims"
+  assertion elsewhere in the package
+- status contradictions: readiness assertions ("filing-ready") anywhere
+  while draft/DO-NOT-FILE/SUPERSEDED markers exist anywhere
+- filing-copy purity: documents marked for filing must carry no bracketed
+  commentary, TODO notes, checker scores, or "Next steps" sections
+- date sanity: future or malformed ISO dates
+"""
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    from analyzer_base import BaseAnalyzer, BaseIssue
+except ImportError:
+    from mcp_server.analyzer_base import BaseAnalyzer, BaseIssue
+
+TEXT_SUFFIXES = {".md", ".txt", ".markdown"}
+MAX_FILE_BYTES = 2 * 1024 * 1024
+
+STAMP_RE = re.compile(r"hash[^`\n]{0,40}`([0-9a-f]{8,64})`", re.IGNORECASE)
+FILE_REF_RE = re.compile(r"`([^`\n]+?\.(?:md|txt|markdown|svg|pdf))`", re.IGNORECASE)
+CLAIM_LINE_RE = re.compile(r"^\s{0,3}(\d{1,3})\.\s+(?:A|An|The)\b")
+CLAIM_COUNT_ASSERTION_RE = re.compile(r"\b(\d{1,3})\s+claims\b", re.IGNORECASE)
+READY_RE = re.compile(r"filing[- ]ready|ready\s+(?:to|for)\s+fil\w*", re.IGNORECASE)
+NEGATION_RE = re.compile(r"\b(?:not|never|isn't|aren't|no)\b[\s:*]*$", re.IGNORECASE)
+# 'is filing-ready' asserts; 'the gate for calling anything filing-ready'
+# merely mentions. Only assertive contexts count.
+ASSERTION_CUE_RE = re.compile(
+    r"(?:\b(?:is|are|now|deemed|considered|declared)\b|\bstatus\b[^\n]{0,10})[\s:*'\"]*$",
+    re.IGNORECASE,
+)
+DRAFT_MARKER_RE = re.compile(
+    r"\bDRAFT\b|DO NOT FILE|\bSUPERSEDED\b|not yet\b", re.IGNORECASE
+)
+FILING_COPY_MARKER_RE = re.compile(r"FILING[- _]COP", re.IGNORECASE)
+IMPURITY_RES = [
+    (re.compile(r"\[(?:NOTE|TODO|STRATEGY|INTERNAL|FIXME)\b", re.IGNORECASE), "bracketed commentary"),
+    (re.compile(r"^#{1,6}\s*next steps\b", re.IGNORECASE | re.MULTILINE), "'Next steps' section"),
+    (re.compile(r"\b\d+\s+critical\b|\bcompliance score\b|\bchecker\b", re.IGNORECASE), "checker/score language"),
+    (re.compile(r"<!--"), "HTML comment"),
+]
+ISO_DATE_RE = re.compile(r"\b(20\d{2})-(\d{2})-(\d{2})\b")
+
+
+@dataclass
+class PackageIssue(BaseIssue):
+    """A package-level consistency issue.
+
+    Attributes:
+        check: Which package check produced the issue (stamp_freshness,
+            claim_count, status_contradiction, filing_copy_purity,
+            date_sanity)
+        file: Package-relative path of the primary file involved
+    """
+
+    check: str = ""
+    file: str = ""
+
+
+class PackageChecker(BaseAnalyzer):
+    """Cross-artifact consistency checker for an assembled package directory."""
+
+    def analyze(self, directory: str) -> dict[str, Any]:
+        root = Path(directory).expanduser()
+        if not root.is_dir():
+            raise ValueError(f"Package directory not found: {directory}")
+
+        files = self._load_files(root)
+        if not files:
+            raise ValueError(
+                f"No text documents (.md/.txt) found under: {directory}"
+            )
+
+        self.issues = []
+        stamps = self._check_stamps(root, files)
+        self._check_claim_counts(files)
+        self._check_status_contradictions(files)
+        self._check_filing_copy_purity(files)
+        self._check_date_sanity(files)
+
+        self._sort_issues(secondary_key=lambda i: (i.check, i.file))
+        counts = self._count_by_severity()
+        score = max(
+            0.0,
+            100.0
+            - 25.0 * counts["critical"]
+            - 10.0 * counts["important"]
+            - 2.0 * counts["minor"],
+        )
+        if counts["total"] == 0:
+            summary = (
+                f"[OK] Package is internally consistent: {len(files)} documents "
+                "scanned, no issues found."
+            )
+        else:
+            summary = (
+                f"[!] {counts['critical']} critical, {counts['important']} important, "
+                f"{counts['minor']} minor package-consistency issues across "
+                f"{len(files)} documents."
+            )
+        return self._generate_base_report(
+            "package_integrity_score",
+            score,
+            summary,
+            additional_data={
+                "files_scanned": len(files),
+                "stamps": stamps,
+            },
+        )
+
+    def _issue_to_dict(self, issue: BaseIssue) -> dict[str, Any]:
+        return {
+            "severity": issue.severity,
+            "check": issue.check,
+            "file": issue.file,
+            "problem": issue.problem,
+            "fix": issue.fix,
+            "legal_ref": issue.legal_ref,
+            "confidence": issue.confidence,
+        }
+
+    def _add(self, severity, check, file, problem, fix, confidence="HIGH"):
+        self.issues.append(
+            PackageIssue(
+                severity=severity,
+                problem=problem,
+                fix=fix,
+                legal_ref="package integrity",
+                confidence=confidence,
+                check=check,
+                file=file,
+            )
+        )
+
+    # ------------------------------------------------------------ loading
+
+    def _load_files(self, root: Path) -> dict[str, str]:
+        """Read every small text document, keyed by package-relative path."""
+        files: dict[str, str] = {}
+        for path in sorted(root.rglob("*")):
+            if path.suffix.lower() not in TEXT_SUFFIXES or not path.is_file():
+                continue
+            try:
+                if path.stat().st_size > MAX_FILE_BYTES:
+                    continue
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            files[path.relative_to(root).as_posix()] = text
+        return files
+
+    # ------------------------------------------------------------- stamps
+
+    def _check_stamps(self, root: Path, files: dict[str, str]) -> list[dict[str, Any]]:
+        stamps: list[dict[str, Any]] = []
+        basenames = {Path(rel).name: rel for rel in files}
+        found: list[tuple[str, str, Optional[str]]] = []
+        for rel, text in files.items():
+            for block in self._blocks(text):
+                for match in STAMP_RE.finditer(block):
+                    found.append(
+                        (rel, match.group(1), self._resolve_target(block, rel, basenames))
+                    )
+        anchored_values = {stamp for _, stamp, target in found if target}
+        for rel, stamp, target in found:
+            record = {"file": rel, "stamp": stamp, "target": target}
+            if target is None:
+                if stamp in anchored_values:
+                    # A bare repeat of a hash anchored elsewhere ('re-vet
+                    # the flags at hash `x`') is a reference, not a stamp.
+                    record["status"] = "reference"
+                else:
+                    record["status"] = "unanchored"
+                    self._add(
+                        "IMPORTANT",
+                        "stamp_freshness",
+                        rel,
+                        f"Verification stamp `{stamp}` in {rel} names no "
+                        "file in the package — it cannot be recomputed, so "
+                        "it verifies nothing.",
+                        "Name the stamped file (backticked) in the same "
+                        "line or paragraph as the stamp.",
+                    )
+            else:
+                actual = hashlib.sha256(
+                    (root / basenames[target]).read_bytes()
+                ).hexdigest()
+                if actual.startswith(stamp):
+                    record["status"] = "fresh"
+                else:
+                    record["status"] = "stale"
+                    self._add(
+                        "CRITICAL",
+                        "stamp_freshness",
+                        rel,
+                        f"Stale verification stamp: {rel} records "
+                        f"{target} at content hash `{stamp}`, but the "
+                        f"file now hashes to `{actual[:12]}`. The file "
+                        "was edited after the recorded check.",
+                        f"Re-run the recorded check against the current "
+                        f"{target} and update the stamp, or revert the "
+                        "unreviewed edit.",
+                    )
+            stamps.append(record)
+        return stamps
+
+    @staticmethod
+    def _blocks(text: str) -> list[str]:
+        """Stamp scope: a table row is its own block; prose splits on blank lines."""
+        blocks: list[str] = []
+        prose: list[str] = []
+        for line in text.splitlines():
+            if line.lstrip().startswith("|"):
+                if prose:
+                    blocks.append("\n".join(prose))
+                    prose = []
+                blocks.append(line)
+            elif line.strip():
+                prose.append(line)
+            else:
+                if prose:
+                    blocks.append("\n".join(prose))
+                    prose = []
+        if prose:
+            blocks.append("\n".join(prose))
+        return blocks
+
+    @staticmethod
+    def _resolve_target(
+        block: str, containing: str, basenames: dict[str, str]
+    ) -> Optional[str]:
+        """The stamped file is a backticked filename in the same block."""
+        for ref in FILE_REF_RE.findall(block):
+            name = Path(ref).name
+            if name in basenames and basenames[name] != containing:
+                return name
+        return None
+
+    # -------------------------------------------------------- claim count
+
+    def _check_claim_counts(self, files: dict[str, str]) -> None:
+        claims_files = {
+            rel: text
+            for rel, text in files.items()
+            if "claim" in Path(rel).name.lower()
+        }
+        if not claims_files:
+            return
+        for claims_rel, claims_text in claims_files.items():
+            numbers = {
+                int(m.group(1))
+                for line in claims_text.splitlines()
+                if (m := CLAIM_LINE_RE.match(line))
+            }
+            if not numbers:
+                continue
+            actual = len(numbers)
+            for rel, text in files.items():
+                for match in CLAIM_COUNT_ASSERTION_RE.finditer(text):
+                    asserted = int(match.group(1))
+                    if asserted != actual:
+                        self._add(
+                            "CRITICAL",
+                            "claim_count",
+                            rel,
+                            f"{rel} asserts {asserted} claims, but "
+                            f"{claims_rel} contains {actual} claims. A claim "
+                            "was added or removed after that assertion was "
+                            "written.",
+                            f"Recount and update {rel}, then re-run any "
+                            "compliance check recorded against the claim set.",
+                        )
+
+    # ----------------------------------------------- status contradictions
+
+    def _check_status_contradictions(self, files: dict[str, str]) -> None:
+        ready_hits: list[tuple[str, str]] = []
+        draft_hits: list[tuple[str, str]] = []
+        for rel, text in files.items():
+            for match in READY_RE.finditer(text):
+                preceding = text[max(0, match.start() - 40) : match.start()]
+                if NEGATION_RE.search(preceding):
+                    continue
+                if not ASSERTION_CUE_RE.search(preceding):
+                    continue
+                ready_hits.append((rel, match.group(0)))
+            for match in DRAFT_MARKER_RE.finditer(text):
+                draft_hits.append((rel, match.group(0)))
+        if ready_hits and draft_hits:
+            ready_rel, ready_text = ready_hits[0]
+            draft_rel, draft_text = draft_hits[0]
+            self._add(
+                "CRITICAL",
+                "status_contradiction",
+                ready_rel,
+                f"{ready_rel} asserts readiness ('{ready_text}') while "
+                f"{draft_rel} carries a draft marker ('{draft_text}'). The "
+                "package contradicts itself about its own status.",
+                "Either the readiness claim or the draft marker is wrong — "
+                "fix the wrong one, then re-check the package.",
+            )
+
+    # ------------------------------------------------- filing-copy purity
+
+    def _check_filing_copy_purity(self, files: dict[str, str]) -> None:
+        for rel, text in files.items():
+            header = "\n".join(
+                [ln for ln in text.splitlines() if ln.strip()][:5]
+            )
+            is_filing_copy = bool(
+                FILING_COPY_MARKER_RE.search(rel)
+                or FILING_COPY_MARKER_RE.search(header)
+            )
+            if not is_filing_copy:
+                continue
+            body = self._strip_filing_copy_marker(text)
+            for pattern, label in IMPURITY_RES:
+                match = pattern.search(body)
+                if match:
+                    self._add(
+                        "CRITICAL",
+                        "filing_copy_purity",
+                        rel,
+                        f"{rel} is marked as a filing copy but contains "
+                        f"{label}: '{match.group(0)[:60]}'. Internal "
+                        "commentary must never reach a filing.",
+                        "Regenerate the filing copy mechanically from the "
+                        "working document, stripping all commentary, and "
+                        "diff-check the result.",
+                    )
+
+    @staticmethod
+    def _strip_filing_copy_marker(text: str) -> str:
+        """The marker itself may be an HTML comment — don't flag it as one."""
+        return re.sub(
+            r"<!--[^>]{0,80}FILING[- _]COP[^>]{0,80}-->", "", text, flags=re.IGNORECASE
+        )
+
+    # --------------------------------------------------------- date sanity
+
+    def _check_date_sanity(self, files: dict[str, str]) -> None:
+        today = date.today()
+        for rel, text in files.items():
+            for match in ISO_DATE_RE.finditer(text):
+                year, month, day = (int(g) for g in match.groups())
+                try:
+                    found = date(year, month, day)
+                except ValueError:
+                    self._add(
+                        "MINOR",
+                        "date_sanity",
+                        rel,
+                        f"Malformed date '{match.group(0)}' in {rel}.",
+                        "Correct the date.",
+                        confidence="MEDIUM",
+                    )
+                    continue
+                if found > today:
+                    self._add(
+                        "IMPORTANT",
+                        "date_sanity",
+                        rel,
+                        f"Future date '{match.group(0)}' in {rel} — records "
+                        "of work cannot postdate today.",
+                        "Correct the date (check timezone drift between "
+                        "local time and UTC file timestamps).",
+                    )

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -48,6 +48,7 @@ from logging_config import get_logger
 from monitoring import log_operation_result, track_performance
 from validation import (
     CheckFormalitiesInput,
+    CheckPackageInput,
     CPCSearchInput,
     FamilySearchInput,
     GetPatentInput,
@@ -77,6 +78,11 @@ except ImportError:
     ClaimsAnalyzer = None
     FormalitiesChecker = None
     SpecificationAnalyzer = None
+
+try:
+    from package_checker import PackageChecker
+except ImportError:
+    PackageChecker = None
 
 # Local modules (imported after the site-packages/env setup above)
 from downloaders import FileDownloader
@@ -310,6 +316,7 @@ from tools.diagram_tools import register_diagram_tools  # noqa: E402
 from tools.epo_analyzer_tools import register_epo_analyzer_tools  # noqa: E402
 from tools.epo_search_tools import register_epo_tools  # noqa: E402
 from tools.mpep_tools import register_mpep_tools  # noqa: E402
+from tools.package_tools import register_package_tools  # noqa: E402
 from tools.patent_law_tools import register_patent_law_tools  # noqa: E402
 from tools.system_tools import register_system_tools  # noqa: E402
 from tools.uspto_search_tools import register_uspto_tools  # noqa: E402
@@ -341,6 +348,17 @@ def _register_all_tools():
         ReviewClaimsInput=ReviewClaimsInput,
         ReviewSpecificationInput=ReviewSpecificationInput,
         CheckFormalitiesInput=CheckFormalitiesInput,
+        track_performance=track_performance,
+        log_operation_result=log_operation_result,
+    )
+
+    register_package_tools(
+        mcp=mcp,
+        PackageChecker=PackageChecker,
+        log_info=_log_info,
+        log_error=_log_error,
+        validate_input=validate_input,
+        CheckPackageInput=CheckPackageInput,
         track_performance=track_performance,
         log_operation_result=log_operation_result,
     )

--- a/mcp_server/tools/__init__.py
+++ b/mcp_server/tools/__init__.py
@@ -3,6 +3,7 @@
 Modules:
     mpep_tools: MPEP manual search and retrieval
     analyzer_tools: Claims, specification, and formalities analysis (US)
+    package_tools: Package-level cross-artifact consistency checks
     epo_analyzer_tools: EPO/PCT claims, specification, formalities
     uspto_search_tools: USPTO API search
     bigquery_tools: BigQuery patent search
@@ -15,6 +16,7 @@ Modules:
 __all__ = [
     "mpep_tools",
     "analyzer_tools",
+    "package_tools",
     "epo_analyzer_tools",
     "uspto_search_tools",
     "bigquery_tools",

--- a/mcp_server/tools/package_tools.py
+++ b/mcp_server/tools/package_tools.py
@@ -1,0 +1,66 @@
+"""Package Consistency Tools
+
+Cross-artifact checks over an assembled filing-package directory —
+the deterministic half of the two-red-teams discipline in the
+patent-application-creator skill.
+
+Tools:
+    - check_package: stamp freshness, claim-count agreement, status
+      contradictions, filing-copy purity, date sanity
+"""
+
+from typing import Any
+
+
+def register_package_tools(
+    mcp,
+    PackageChecker,
+    log_info,
+    log_error,
+    validate_input,
+    CheckPackageInput,
+    track_performance,
+    log_operation_result,
+):
+    """Register package-consistency tools with the MCP server.
+
+    Args:
+        mcp: FastMCP server instance
+        PackageChecker: Package checker class (None if unavailable)
+        log_info: Logging function for info messages
+        log_error: Logging function for error messages
+        validate_input: Input validation function
+        CheckPackageInput: Pydantic model for package check validation
+        track_performance: Performance tracking decorator
+        log_operation_result: Operation result logging function
+    """
+
+    @mcp.tool()
+    @track_performance("tool_check_package")
+    def check_package(directory: str) -> dict[str, Any]:
+        """Check an assembled filing-package directory for cross-artifact consistency: stale content-hash verification stamps (edit-after-check), claim-count disagreements between documents, status contradictions (readiness claims beside draft markers), commentary inside filing copies, and future/malformed dates. Per-document checkers cannot see these — run this on the whole package directory before calling anything filing-ready."""
+        try:
+            validated = validate_input(CheckPackageInput, directory=directory)
+            directory = validated.directory
+
+            log_info("check_package_started", directory=directory)
+
+            if PackageChecker is None:
+                return {"error": "Package checker is not available."}
+
+            checker = PackageChecker()
+            report = checker.analyze(directory)
+
+            log_operation_result(
+                "check_package",
+                success=True,
+                files_scanned=report.get("files_scanned"),
+                critical=report.get("critical_issues"),
+            )
+            return report
+        except ValueError as e:
+            log_error("check_package_failed", error=str(e))
+            return {"error": str(e)}
+        except Exception as e:
+            log_error("check_package_failed", error=str(e))
+            return {"error": f"Package check failed: {e}"}

--- a/mcp_server/validation.py
+++ b/mcp_server/validation.py
@@ -274,6 +274,14 @@ class CheckFormalitiesInput(BaseModel):  # type: ignore[misc]
     drawings_present: bool = Field(default=False, description="Whether drawings are included")
 
 
+class CheckPackageInput(BaseModel):  # type: ignore[misc]
+    """Input validation for package consistency checking."""
+
+    directory: constr(min_length=1, max_length=4096) = Field(  # type: ignore[valid-type]
+        ..., description="Path to the assembled filing-package directory"
+    )
+
+
 # Diagram Input Models
 
 

--- a/skills/patent-application-creator/SKILL.md
+++ b/skills/patent-application-creator/SKILL.md
@@ -175,7 +175,13 @@ the defeated element to a dependent — then re-run Phase 4 on the changed
 claims.
 
 **5b. Package red team (the whole artifact).** Attacking the claims is not
-enough: a package can have perfect claims and still be unfit to file. Hand
+enough: a package can have perfect claims and still be unfit to file.
+First run the deterministic gate: `check_package` on the assembled
+directory. It recomputes every content-hash verification stamp (an edit
+after a recorded check is a critical failure), cross-checks claim counts
+against every "N claims" assertion, flags readiness language beside draft
+markers, catches commentary inside filing copies, and sanity-checks
+dates. Fix every critical before spending reviewer effort. Then hand
 the ASSEMBLED package — every file, nothing else — to a fresh adversarial
 reviewer with zero campaign context, tasked to find: internal
 contradictions between README, claims, spec, and figures; statements of

--- a/tests/test_package_checker.py
+++ b/tests/test_package_checker.py
@@ -1,0 +1,320 @@
+"""Package-level consistency checks (check_package).
+
+An external zero-context review caught an assembled filing package whose
+per-artifact checks all passed while the PACKAGE lied about itself: a README
+claiming "verified" beside a stale draft header, a claim added after its
+recorded compliance check, and strategy commentary inside documents marked
+for filing. These tests pin the deterministic tooling half of that fix
+(the skill half shipped in PR #59).
+
+Stamp convention: a verification stamp is a backticked lowercase-hex prefix
+of the SHA-256 of the target file's raw bytes, written near the word "hash"
+(e.g. "checked at content hash `ef5315850dfb`"). A stamp that cannot be
+recomputed to a match is stale by definition — unverifiable equals
+unverified.
+"""
+
+import hashlib
+
+import pytest
+
+from mcp_server.package_checker import PackageChecker
+
+
+def _sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _issues_for(report, check):
+    return [i for i in report["issues"] if i["check"] == check]
+
+
+@pytest.fixture
+def checker():
+    return PackageChecker()
+
+
+# ---------------------------------------------------------------- stamps
+
+
+def test_fresh_stamp_passes(tmp_path, checker):
+    spec = tmp_path / "spec.md"
+    spec.write_text("The invention.\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        f"`spec.md` checked: 0 critical issues at content hash `{_sha(spec)[:12]}`.\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "stamp_freshness") == []
+    stamps = report["stamps"]
+    assert len(stamps) == 1
+    assert stamps[0]["status"] == "fresh"
+    assert stamps[0]["target"] == "spec.md"
+
+
+def test_stale_stamp_is_critical(tmp_path, checker):
+    spec = tmp_path / "spec.md"
+    spec.write_text("The invention.\n", encoding="utf-8")
+    stamp = _sha(spec)[:12]
+    (tmp_path / "README.md").write_text(
+        f"`spec.md` checked: 0 critical issues at content hash `{stamp}`.\n",
+        encoding="utf-8",
+    )
+    # Edit AFTER the recorded check — the exact edit-after-check failure.
+    spec.write_text("The invention, edited later.\n", encoding="utf-8")
+
+    report = checker.analyze(str(tmp_path))
+
+    issues = _issues_for(report, "stamp_freshness")
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "CRITICAL"
+    assert "spec.md" in issues[0]["problem"]
+    assert stamp in issues[0]["problem"]
+
+
+def test_unanchored_stamp_is_flagged(tmp_path, checker):
+    (tmp_path / "README.md").write_text(
+        "Compliance checked at content hash `deadbeef1234`.\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    issues = _issues_for(report, "stamp_freshness")
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "IMPORTANT"
+    assert "deadbeef1234" in issues[0]["problem"]
+
+
+def test_stamp_target_resolves_within_table_row(tmp_path, checker):
+    """The KRW README records stamps in a table — one file per row."""
+    spec = tmp_path / "spec.md"
+    claims = tmp_path / "claims.md"
+    spec.write_text("Spec body.\n", encoding="utf-8")
+    claims.write_text("1. A method.\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        "| File | State |\n| --- | --- |\n"
+        f"| `spec.md` | 0 critical at content hash `{_sha(spec)[:12]}` |\n"
+        f"| `claims.md` | checked at content hash `{'0' * 12}` |\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    by_target = {s["target"]: s["status"] for s in report["stamps"]}
+    assert by_target["spec.md"] == "fresh"
+    assert by_target["claims.md"] == "stale"
+
+
+# ------------------------------------------------------------ claim count
+
+
+def test_claim_count_mismatch_is_critical(tmp_path, checker):
+    (tmp_path / "KRW-Claims.md").write_text(
+        "1. A method comprising steps.\n"
+        "2. The method of claim 1, wherein.\n"
+        "3. The method of claim 2, wherein.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "Working claims file (17 claims, 3 independent).\n", encoding="utf-8"
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    issues = _issues_for(report, "claim_count")
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "CRITICAL"
+    assert "17" in issues[0]["problem"] and "3" in issues[0]["problem"]
+
+
+def test_matching_claim_count_passes(tmp_path, checker):
+    (tmp_path / "claims-v2.md").write_text(
+        "1. A method comprising steps.\n"
+        "2. The method of claim 1, wherein.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text("Contains 2 claims.\n", encoding="utf-8")
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "claim_count") == []
+
+
+# ---------------------------------------------------- status contradiction
+
+
+def test_ready_assertion_beside_draft_marker_is_critical(tmp_path, checker):
+    (tmp_path / "README.md").write_text(
+        "This package is filing-ready.\n", encoding="utf-8"
+    )
+    (tmp_path / "claims.md").write_text(
+        "DRAFT — not yet compliance-checked.\n1. A method.\n", encoding="utf-8"
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    issues = _issues_for(report, "status_contradiction")
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "CRITICAL"
+    assert "README.md" in issues[0]["problem"]
+    assert "claims.md" in issues[0]["problem"]
+
+
+def test_negated_readiness_is_not_a_contradiction(tmp_path, checker):
+    """'Status: NOT filing-ready' is the honest form — never flag it."""
+    (tmp_path / "README.md").write_text(
+        "**Status: NOT filing-ready.** Open work remains.\n", encoding="utf-8"
+    )
+    (tmp_path / "claims.md").write_text(
+        "DRAFT working claims.\n1. A method.\n", encoding="utf-8"
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "status_contradiction") == []
+
+
+def test_meta_mention_of_readiness_is_not_an_assertion(tmp_path, checker):
+    """'the gate for calling anything filing-ready' describes a process —
+    only assertive contexts ('is filing-ready', 'Status: filing-ready') count."""
+    (tmp_path / "README.md").write_text(
+        "A fresh zero-context review is the gate for calling anything "
+        "filing-ready.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "claims.md").write_text(
+        "DRAFT working claims.\n1. A method.\n", encoding="utf-8"
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "status_contradiction") == []
+
+
+def test_repeat_mention_of_anchored_stamp_is_not_unanchored(tmp_path, checker):
+    """A hash anchored to a file in one paragraph may be referenced bare in
+    another ('re-vet the flags at hash `x`') without being a new stamp."""
+    spec = tmp_path / "spec.md"
+    spec.write_text("Spec body.\n", encoding="utf-8")
+    stamp = _sha(spec)[:12]
+    (tmp_path / "README.md").write_text(
+        f"`spec.md` checked at content hash `{stamp}`.\n\n"
+        f"Re-vet the open flags recorded at hash `{stamp}`.\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "stamp_freshness") == []
+    assert [s["status"] for s in report["stamps"] if s["target"]] == ["fresh"]
+
+
+# ------------------------------------------------------ filing-copy purity
+
+
+def test_commentary_in_filing_copy_is_critical(tmp_path, checker):
+    copies = tmp_path / "filing-copies"
+    copies.mkdir()
+    (copies / "claims.md").write_text(
+        "1. A method comprising steps.\n"
+        "[NOTE: broaden this after examiner feedback]\n"
+        "## Next steps\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    issues = _issues_for(report, "filing_copy_purity")
+    assert issues, "commentary inside a filing copy must be flagged"
+    assert all(i["severity"] == "CRITICAL" for i in issues)
+
+
+def test_working_documents_may_contain_commentary(tmp_path, checker):
+    (tmp_path / "claims-working.md").write_text(
+        "1. A method.\n[NOTE: internal strategy commentary is fine here]\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "filing_copy_purity") == []
+
+
+def test_filing_copy_marker_in_header_is_recognized(tmp_path, checker):
+    (tmp_path / "claims-final.md").write_text(
+        "<!-- FILING COPY -->\n1. A method.\n[TODO tighten]\n",
+        encoding="utf-8",
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "filing_copy_purity")
+
+
+# ------------------------------------------------------------- date sanity
+
+
+def test_future_date_is_flagged(tmp_path, checker):
+    (tmp_path / "README.md").write_text(
+        "Assembled 2099-01-01 from verified sources.\n", encoding="utf-8"
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    issues = _issues_for(report, "date_sanity")
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "IMPORTANT"
+    assert "2099-01-01" in issues[0]["problem"]
+
+
+def test_past_dates_pass(tmp_path, checker):
+    (tmp_path / "README.md").write_text(
+        "Assembled 2026-07-10; reviewed 2026-07-11.\n", encoding="utf-8"
+    )
+
+    report = checker.analyze(str(tmp_path))
+
+    assert _issues_for(report, "date_sanity") == []
+
+
+# ---------------------------------------------------------------- reporting
+
+
+def test_clean_package_reports_compliant(tmp_path, checker):
+    spec = tmp_path / "spec.md"
+    spec.write_text("The invention, fully described.\n", encoding="utf-8")
+    (tmp_path / "claims.md").write_text("1. A method comprising steps.\n", encoding="utf-8")
+    readme = (
+        f"Working package, 1 claims. `spec.md` at content hash `{_sha(spec)[:12]}`.\n"
+    )
+    (tmp_path / "README.md").write_text(readme, encoding="utf-8")
+
+    report = checker.analyze(str(tmp_path))
+
+    assert report["critical_issues"] == 0
+    assert report["package_integrity_score"] == 100.0
+    assert report["files_scanned"] == 3
+    assert "compliant" in report["summary"].lower() or "no issues" in report["summary"].lower()
+
+
+def test_missing_directory_raises(checker):
+    with pytest.raises(ValueError):
+        checker.analyze(r"C:\does\not\exist-anywhere-42")
+
+
+def test_empty_directory_raises(tmp_path, checker):
+    with pytest.raises(ValueError):
+        checker.analyze(str(tmp_path))
+
+
+def test_server_registers_check_package_tool():
+    """server.py must wire the tool (server.py itself is not importable here)."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    server_src = (root / "mcp_server" / "server.py").read_text(encoding="utf-8")
+    assert "register_package_tools" in server_src
+    assert "CheckPackageInput" in server_src


### PR DESCRIPTION
Closes #61.

Per-artifact checkers (`review_patent_claims`, `review_specification`, `check_formalities`) each validate one document in isolation. An external zero-context review caught an assembled package whose per-document checks all passed while the package lied about itself: a README claiming *verified* beside a stale draft header, a claim added after its recorded compliance check, and strategy commentary riding inside documents marked for filing. PR #59 encoded the discipline in the skill; this PR ships the deterministic half.

## New tool: `check_package(directory)`

| Check | What it catches |
|---|---|
| `stamp_freshness` | Content-hash verification stamps are recomputed (SHA-256 prefix of the named file's bytes). Edit-after-check ⇒ **critical**. Unresolvable stamps verify nothing ⇒ important. Bare repeats of an anchored hash are references, not stamps. |
| `claim_count` | Every "N claims" assertion in the package vs the actual claim count in the claims file. |
| `status_contradiction` | Assertive readiness language ('is filing-ready') anywhere while draft/DO-NOT-FILE/SUPERSEDED markers exist anywhere. Negated ('NOT filing-ready') and meta mentions ('the gate for calling anything filing-ready') are not assertions. |
| `filing_copy_purity` | Bracketed commentary, TODOs, checker/score language, 'Next steps' sections inside documents marked FILING COPY. |
| `date_sanity` | Future and malformed ISO dates. |

## Verified against the package that motivated the issue

Run on the real working package: **3 criticals, all true, zero false positives** — both recorded stamps are stale (files edited after their checks), and a compliance note records "16 claims parsed" in a file that now holds 17 claims. That last one is the exact failure class the external reviewer caught by hand; it is now caught deterministically.

Two false positives surfaced during that run and were fixed test-first: meta-language readiness mentions, and bare references to an already-anchored hash.

## Wiring

- `mcp_server/package_checker.py` — stdlib-only `PackageChecker(BaseAnalyzer)`
- `mcp_server/tools/package_tools.py` — MCP tool wrapper, registered in `server.py`
- `CheckPackageInput` validation model
- Skill phase 5b now runs `check_package` as the deterministic gate before the fresh-eyes package red team
- README analysis-tool table row

19 new tests; full suite 196 passing.