### PR TITLE
fix: classify claim dependency by reference phrase, not body-wide mention

### DIFF
--- a/mcp_server/claims_analyzer.py
+++ b/mcp_server/claims_analyzer.py
@@ -130,24 +130,38 @@ class ClaimsAnalyzer(BaseAnalyzer):
         matches = claim_pattern.findall(claims_text)
 
         for claim_num, claim_body in matches:
-            claim = {
-                "number": int(claim_num),
-                "text": claim_body.strip(),
-                # Plural "claims 1 to 5" / "claims 1 and 2" are the standard way
-                # to write multiple-dependent claims; the old `claim \d+` pattern
-                # missed them, mislabeling those dependent claims as independent.
-                "is_independent": not bool(re.search(r"\bclaims?\s+\d+", claim_body, re.IGNORECASE)),
-                "depends_on": None,
-                "elements": {},
-                "limitations": [],
-            }
-
-            # Check for dependency
-            dep_match = re.search(r"\bclaims?\s+(\d+)", claim_body, re.IGNORECASE)
+            # A dependency is a REFERENCE PHRASE in the claim's opening
+            # ("The method of claim 1, wherein..."), per 37 CFR 1.75(c) —
+            # not a bare "claim N" anywhere in the body. The old body-wide
+            # search misclassified independent claims when working-copy
+            # commentary (swallowed into the preceding claim's body by the
+            # split above) mentioned another claim, and when a claim's own
+            # limitations used the word "claims" (issue #65). The phrase
+            # forms cover US and EP styles, including multiple-dependent
+            # "of any one of claims 1 to 5"; searching only the preamble
+            # (text before the first colon, capped at 300 chars) keeps
+            # later prose out of the classification.
+            preamble = claim_body.split(":", 1)[0][:300]
+            dep_match = re.search(
+                r"\b(?:of|according to|as\s+(?:claimed|recited|defined|set\s+forth)\s+in)\s+"
+                r"(?:any\s+(?:one\s+)?of\s+(?:the\s+)?(?:preceding\s+)?)?claims?\s+(\d+)",
+                preamble,
+                re.IGNORECASE,
+            )
+            depends_on = None
             if dep_match:
                 dep_num = int(dep_match.group(1))
                 if dep_num != int(claim_num):  # Prevent self-referencing
-                    claim["depends_on"] = dep_num
+                    depends_on = dep_num
+
+            claim = {
+                "number": int(claim_num),
+                "text": claim_body.strip(),
+                "is_independent": depends_on is None,
+                "depends_on": depends_on,
+                "elements": {},
+                "limitations": [],
+            }
 
             # Extract limitations (a), (b), (c), etc.
             lim_pattern = re.compile(r"\n\s*([a-z])\)\s+(.+?)(?=\n\s*[a-z]\)|$)", re.DOTALL)

--- a/tests/test_claim_dependency_classification.py
+++ b/tests/test_claim_dependency_classification.py
@@ -1,0 +1,90 @@
+"""Independent/dependent claim classification (issue #65).
+
+The old classifier called a claim dependent if "claim N" appeared ANYWHERE
+in its body. Two real failure modes:
+
+1. Working-copy claim files interleave commentary between claims; the
+   parser swallows commentary into the preceding claim's body, so an
+   independent claim followed by commentary that mentions another claim
+   gets misclassified as dependent. Observed on a real 17-claim set:
+   3 independent claims by inspection, analyzer reported 1.
+
+2. A genuine dependency is recited as a reference phrase in the claim's
+   preamble ("The method of claim 1, wherein..."), which is the legal form
+   (37 CFR 1.75(c)) — not as a bare mention anywhere.
+"""
+
+import pytest
+
+from mcp_server.claims_analyzer import ClaimsAnalyzer
+
+
+@pytest.fixture
+def analyzer():
+    return ClaimsAnalyzer()
+
+
+def _parse(analyzer, text):
+    return {c["number"]: c for c in analyzer._parse_claims(text)}
+
+
+def test_dependent_forms_are_recognized(analyzer):
+    text = (
+        "1. A method comprising a step.\n"
+        "2. The method of claim 1, wherein the step repeats.\n"
+        "3. The method according to claim 2, wherein the step halts.\n"
+        "4. The method as claimed in claim 1, further comprising logging.\n"
+        "5. The method of any one of claims 1 to 4, wherein logging is disabled.\n"
+    )
+    claims = _parse(analyzer, text)
+    assert claims[1]["is_independent"]
+    for n in (2, 3, 4, 5):
+        assert not claims[n]["is_independent"], f"claim {n} should be dependent"
+    assert claims[2]["depends_on"] == 1
+    assert claims[5]["depends_on"] == 1
+
+
+def test_independent_claim_followed_by_commentary_stays_independent(analyzer):
+    """The exact #65 failure: commentary mentioning other claims gets
+    swallowed into the preceding claim's body."""
+    text = (
+        "1. A method for reconciling marks, comprising refusing a relocation.\n"
+        "\n"
+        "   [Commentary: this walls off claim 14 of US7747943B2.]\n"
+        "\n"
+        "8. A computer-implemented method for managing dismissals, comprising\n"
+        "   storing an embedding vector.\n"
+        "\n"
+        "   [Load-bearing vs art: pair of snapshots; compare claims 1 and 3\n"
+        "   of the Amazon patent.]\n"
+        "\n"
+        "14. A computer-implemented method for controlling iterative text\n"
+        "   generation under a first budget and a second budget.\n"
+    )
+    claims = _parse(analyzer, text)
+    assert claims[1]["is_independent"]
+    assert claims[8]["is_independent"], "commentary must not make claim 8 dependent"
+    assert claims[14]["is_independent"]
+
+
+def test_body_mention_of_claim_terminology_is_not_a_dependency(analyzer):
+    """A claim about claims (e.g. patent-drafting software) may use the
+    word 'claim' in its own limitations without depending on anything."""
+    text = (
+        "1. A method comprising displaying claims 1 to 20 of a patent "
+        "document on a screen.\n"
+    )
+    claims = _parse(analyzer, text)
+    assert claims[1]["is_independent"]
+
+
+def test_report_counts_reflect_classification(analyzer):
+    text = (
+        "1. A method comprising a step.\n"
+        "2. The method of claim 1, wherein the step repeats.\n"
+        "8. A system comprising a processor.\n"
+    )
+    report = analyzer.analyze_claims(text)
+    assert report["claim_count"] == 3
+    assert report["independent_count"] == 2
+    assert report["dependent_count"] == 1


### PR DESCRIPTION
Closes #65.

A claim was called dependent if `claim N` appeared **anywhere** in its body. Working claim files interleave commentary between claims, and the parser's claim-splitter swallows that commentary into the preceding claim's body — so an independent claim followed by commentary citing prior art claims got misclassified. A claim whose own limitations use the word "claims" (e.g. software that displays patent claims) hit the same bug. Observed on a real 17-claim set with 3 independent claims: `independent_claims: 1`.

Dependency is now recognized the way it's legally written (37 CFR 1.75(c)): a reference phrase in the claim's preamble — `of claim 1`, `according to claim 2`, `as claimed in claim 3`, `of any one of claims 1 to 5` (multiple-dependent, US and EP styles). `depends_on` comes from the same match, so antecedent-registry building is unaffected for real dependents.

Verified against the motivating file: **17 claims, 3 independent, 14 dependent** — matches inspection (claims 1, 8, 14).

Also in this train: closed #62 as not-reproducible on current main with evidence (fresh live 17-claim run shows full claim attribution on all 27 issues).

4 new tests; suite at 200 passing.