### PR TITLE
feat: labelable flowchart decision branches

### DIFF
--- a/mcp_server/diagram_generator.py
+++ b/mcp_server/diagram_generator.py
@@ -129,10 +129,14 @@ class PatentDiagramGenerator:
             [
                 {"id": "start", "label": "Start", "shape": "ellipse", "next": ["step1"]},
                 {"id": "step1", "label": "Process data", "shape": "box", "next": ["decision"]},
-                {"id": "decision", "label": "Valid?", "shape": "diamond", "next": ["step2", "end"]},
+                {"id": "decision", "label": "Valid?", "shape": "diamond",
+                 "next": [{"id": "step2", "label": "Yes"}, {"id": "end", "label": "No"}]},
                 {"id": "step2", "label": "Save result", "shape": "box", "next": ["end"]},
                 {"id": "end", "label": "End", "shape": "ellipse", "next": []}
             ]
+
+        A "next" entry is either a step-id string or {"id", "label"} to
+        label the edge (required for unambiguous decision branches).
         """
         # Build DOT code
         dot_lines = [
@@ -153,13 +157,27 @@ class PatentDiagramGenerator:
 
         dot_lines.append("")
 
-        # Add edges
+        # Add edges. A `next` entry is a step-id string, or {"id", "label"}
+        # to label the edge — decision-diamond branches need Yes/No labels
+        # to be unambiguous in a patent figure (issue #60).
         for step in steps:
             node_id = step["id"]
             next_nodes = step.get("next", [])
 
             for next_node in next_nodes:
-                dot_lines.append(f'    "{node_id}" -> "{next_node}";')
+                if isinstance(next_node, dict):
+                    target = next_node["id"]
+                    edge_label = next_node.get("label", "")
+                else:
+                    target = next_node
+                    edge_label = ""
+                if edge_label:
+                    escaped = edge_label.replace('"', '\\"')
+                    dot_lines.append(
+                        f'    "{node_id}" -> "{target}" [label="{escaped}"];'
+                    )
+                else:
+                    dot_lines.append(f'    "{node_id}" -> "{target}";')
 
         dot_lines.append("}")
 

--- a/mcp_server/tools/diagram_tools.py
+++ b/mcp_server/tools/diagram_tools.py
@@ -152,7 +152,10 @@ def register_diagram_tools(
                 - "id": Unique identifier (e.g., "start", "step1")
                 - "label": Display label (e.g., "Initialize System")
                 - "shape": Node shape - "box" (default), "ellipse" (start/end), "diamond" (decision)
-                - "next": List of next step IDs (e.g., ["step2", "step3"])
+                - "next": List of next steps — plain IDs (e.g., ["step2"]) or
+                  {"id": ..., "label": ...} objects to label the edge
+                  (e.g., [{"id": "step2", "label": "Yes"}, {"id": "end", "label": "No"}]).
+                  Decision-diamond branches MUST be labeled to be unambiguous.
             filename: Output filename (default: "flowchart")
             output_format: Output format - "svg" (default), "png", or "pdf"
 
@@ -163,7 +166,8 @@ def register_diagram_tools(
             [
                 {"id": "start", "label": "Start", "shape": "ellipse", "next": ["step1"]},
                 {"id": "step1", "label": "Process Data", "shape": "box", "next": ["decision"]},
-                {"id": "decision", "label": "Valid?", "shape": "diamond", "next": ["step2", "end"]},
+                {"id": "decision", "label": "Valid?", "shape": "diamond",
+                 "next": [{"id": "step2", "label": "Yes"}, {"id": "end", "label": "No"}]},
                 {"id": "step2", "label": "Save Result", "shape": "box", "next": ["end"]},
                 {"id": "end", "label": "End", "shape": "ellipse", "next": []}
             ]

--- a/tests/test_flowchart_edge_labels.py
+++ b/tests/test_flowchart_edge_labels.py
@@ -1,0 +1,63 @@
+"""Flowchart decision branches must be labelable (issue #60).
+
+Patent flowcharts (MPEP 608.02) need Yes/No labels on decision-diamond
+branches; unlabeled branch edges are ambiguous. `next` entries may be
+plain step-id strings (back-compat) or {"id": ..., "label": ...} objects.
+"""
+
+import pytest
+
+from mcp_server.diagram_generator import PatentDiagramGenerator
+
+
+@pytest.fixture
+def dot_of(tmp_path, monkeypatch):
+    """Run create_flowchart but capture the DOT instead of rendering."""
+    generator = PatentDiagramGenerator(output_dir=tmp_path)
+    captured = {}
+
+    def fake_render(dot_code, filename, output_format):
+        captured["dot"] = dot_code
+        return tmp_path / f"{filename}.{output_format}"
+
+    monkeypatch.setattr(generator, "render_dot_diagram", fake_render)
+
+    def run(steps):
+        generator.create_flowchart(steps=steps)
+        return captured["dot"]
+
+    return run
+
+
+def test_labeled_branch_edges(dot_of):
+    dot = dot_of(
+        [
+            {"id": "decision", "label": "Valid?", "shape": "diamond",
+             "next": [{"id": "save", "label": "Yes"}, {"id": "end", "label": "No"}]},
+            {"id": "save", "label": "Save", "shape": "box", "next": ["end"]},
+            {"id": "end", "label": "End", "shape": "ellipse", "next": []},
+        ]
+    )
+    assert '"decision" -> "save" [label="Yes"];' in dot
+    assert '"decision" -> "end" [label="No"];' in dot
+
+
+def test_plain_string_next_still_works(dot_of):
+    dot = dot_of(
+        [
+            {"id": "a", "label": "A", "next": ["b"]},
+            {"id": "b", "label": "B", "next": []},
+        ]
+    )
+    assert '"a" -> "b";' in dot
+
+
+def test_label_quotes_are_escaped(dot_of):
+    dot = dot_of(
+        [
+            {"id": "a", "label": "A",
+             "next": [{"id": "b", "label": 'edge "label"'}]},
+            {"id": "b", "label": "B", "next": []},
+        ]
+    )
+    assert '"a" -> "b" [label="edge \\"label\\""];' in dot


### PR DESCRIPTION
Closes #60.

`create_flowchart`'s `next` entries were unlabeled id strings, so a decision diamond's outgoing edges couldn't say Yes/No — ambiguous in a patent figure, and the KRW campaign had to abandon the tool for hand-written DOT to make FIG. 3/FIG. 5 filing-grade.

`next` entries now accept `{"id": ..., "label": ...}` objects alongside plain strings (fully back-compatible). Labels are quote-escaped into the DOT. Tool docstring updated so agents discover the form.

3 new tests (labeled branches, string back-compat, quote escaping); suite at 203 passing.