### PR TITLE
feat: wire EPO/PCT law corpus into setup; make downloads honest

### DIFF
--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -67,6 +67,22 @@ except (ImportError, SystemExit) as exc:  # SystemExit: server.py exits if mcp i
     download_35_usc = download_37_cfr = download_mpep_pdfs = None
     download_subsequent_publications = extract_mpep_pdfs = None
 
+# EPO/PCT law corpus downloaders (lightweight: requests only). Guarded the
+# same way so `patent-creator --help` works in a bare environment.
+try:
+    from epo_downloaders import (
+        check_epo_pct_sources,
+        download_epc,
+        download_pct_guidelines,
+        download_pct_rules,
+        download_pct_treaty,
+        scrape_epo_guidelines,
+    )
+except ImportError:
+    check_epo_pct_sources = download_epc = None
+    download_pct_guidelines = download_pct_rules = download_pct_treaty = None
+    scrape_epo_guidelines = None
+
 # Import path utilities for cross-platform path handling
 try:
     from path_utils import PathFormatter
@@ -506,6 +522,53 @@ def _setup_graphviz(ensure_fn=None) -> bool:
     return ready
 
 
+def _setup_epo_pct_sources(dest_dir) -> bool:
+    """Download any missing EPO/PCT law sources into dest_dir (issue #49).
+
+    Best effort by design: EPO/WIPO being unreachable must never block US
+    setup — the law-search tools already say honestly when a corpus is
+    missing (#48). Returns True if at least one new source landed, so the
+    caller knows the index needs a rebuild to make it searchable.
+    """
+    if check_epo_pct_sources is None:
+        return False
+
+    downloaders = {
+        "epc": ("EPC (European Patent Convention)", download_epc),
+        "epo_guidelines": ("EPO Guidelines", scrape_epo_guidelines),
+        "pct_treaty": ("PCT Treaty", download_pct_treaty),
+        "pct_rules": ("PCT Regulations", download_pct_rules),
+        "pct_guidelines": ("PCT Guidelines", download_pct_guidelines),
+    }
+
+    try:
+        status = check_epo_pct_sources(dest_dir)
+    except Exception as e:
+        print(f"  EPO/PCT source check failed: {e}", file=sys.stderr)
+        return False
+
+    got_new = False
+    for key, (label, download_fn) in downloaders.items():
+        if status.get(key):
+            print(f"  {label}: [OK]", file=sys.stderr)
+            continue
+        try:
+            ok = download_fn(dest_dir)
+        except Exception as e:
+            print(f"  {label}: [X] {e}", file=sys.stderr)
+            continue
+        if ok:
+            got_new = True
+            print(f"  {label}: [OK] downloaded", file=sys.stderr)
+        else:
+            print(
+                f"  {label}: [X] download failed (EPO/PCT law search will "
+                "report the missing corpus honestly)",
+                file=sys.stderr,
+            )
+    return got_new
+
+
 def setup_command(args):
     """
     One-command setup: installs PyTorch, downloads all sources, and builds index
@@ -597,10 +660,20 @@ def setup_command(args):
     else:
         print("\n[OK] All sources already present", file=sys.stderr)
 
-    # Build index
-    index_exists = (INDEX_DIR / "mpep_index.faiss").exists()
+    # EPO/PCT law corpus (issue #49): best effort, never blocks US setup.
+    print("\nChecking EPO/PCT law sources...", file=sys.stderr)
+    epo_sources_added = _setup_epo_pct_sources(MPEP_DIR)
 
-    if args.rebuild or not index_exists:
+    # Build index. Newly downloaded EPO/PCT sources require a rebuild —
+    # an existing index knows nothing about them.
+    index_exists = (INDEX_DIR / "mpep_index.faiss").exists()
+    if epo_sources_added and index_exists and not args.rebuild:
+        print(
+            "\n  New EPO/PCT sources downloaded — rebuilding index to include them.",
+            file=sys.stderr,
+        )
+
+    if args.rebuild or not index_exists or epo_sources_added:
         print("\n[4/4] Building search index...", file=sys.stderr)
         print("This will take 5-15 minutes on first run.\n", file=sys.stderr)
 
@@ -998,6 +1071,14 @@ def download_all_command(args):
 
     download_subsequent_publications()
     print("[OK] Updates complete", file=sys.stderr)
+
+    print("\nEPO/PCT law sources:", file=sys.stderr)
+    if _setup_epo_pct_sources(MPEP_DIR):
+        print(
+            "  New EPO/PCT sources downloaded — run `patent-creator setup --rebuild` "
+            "(or build-index) to make them searchable.",
+            file=sys.stderr,
+        )
 
     if success:
         print("\n[OK] All source downloads completed successfully", file=sys.stderr)

--- a/mcp_server/epo_downloaders.py
+++ b/mcp_server/epo_downloaders.py
@@ -48,7 +48,9 @@ def _log_error(msg: str, **kwargs):
 # =============================================================================
 
 # EPC: 17th edition (Jul 2020) from WIPO Lex - includes Convention + Implementing Regulations
-EPC_DOWNLOAD_URL = "https://www.wipo.int/wipolex/en/text/312166"
+# Direct PDF published on the EPO's own EPC legal-texts page — the old
+# WIPO wipolex URL served an HTML page that got saved as epc_convention.pdf.
+EPC_DOWNLOAD_URL = "https://link.epo.org/web/EPC_17th_edition_2020_en.pdf"
 
 # PCT Treaty text (in force April 1, 2002)
 PCT_TREATY_URL = "https://www.wipo.int/documents/d/pct-system/docs-en-texts-pct.pdf"
@@ -103,11 +105,25 @@ def _download_file(url: str, dest_path: Path, description: str, timeout: int = 1
         dest_path.parent.mkdir(parents=True, exist_ok=True)
 
         downloaded = 0
+        first_bytes = b""
 
         with dest_path.open("wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
+                if len(first_bytes) < 5:
+                    first_bytes += chunk[: 5 - len(first_bytes)]
                 f.write(chunk)
                 downloaded += len(chunk)
+
+        # A .pdf destination must actually be a PDF — servers answer moved
+        # or blocked documents with HTML error/landing pages, and saving one
+        # as .pdf poisons the index build downstream.
+        if dest_path.suffix.lower() == ".pdf" and not first_bytes.startswith(b"%PDF-"):
+            _log_error(
+                f"{description}: server returned non-PDF content "
+                f"(starts with {first_bytes!r}); discarding"
+            )
+            dest_path.unlink()
+            return False
 
         size_mb = downloaded / (1024 * 1024)
         _log_info(f"Downloaded {description} ({size_mb:.1f} MB)")
@@ -200,14 +216,40 @@ def scrape_epo_guidelines(dest_dir: Path, year: Optional[int] = None) -> bool:
 
     _log_info(f"Attempting EPO Guidelines PDF download for {year}...")
     if _download_file(pdf_url, pdf_dest, f"EPO Guidelines {year} PDF"):
-        # If PDF downloaded, we'll use it directly (extractor handles PDF)
-        # Create a symlink or copy reference
-        _log_info(f"EPO Guidelines PDF obtained for {year}")
-        return True
+        # The index build reads EPO_GUIDELINES_FILE (text) only — a stranded
+        # year-stamped PDF would never be indexed and never satisfy the
+        # presence check, so setup would re-download it every run.
+        if _pdf_to_guidelines_text(pdf_dest, dest_path):
+            _log_info(f"EPO Guidelines PDF obtained and extracted for {year}")
+            return True
+        _log_error("Guidelines PDF text extraction failed; trying HTML scrape")
 
     # Fall back to HTML scraping
     _log_info("PDF not available, scraping HTML version...")
     return _scrape_epo_guidelines_html(dest_path)
+
+
+def _pdf_to_guidelines_text(pdf_path: Path, dest_path: Path) -> bool:
+    """Extract the Guidelines PDF into the canonical text file."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError:
+        _log_error("PyMuPDF not available; cannot extract Guidelines PDF")
+        return False
+    try:
+        doc = fitz.open(pdf_path)
+        try:
+            pages = [doc[p].get_text() for p in range(len(doc))]
+        finally:
+            doc.close()
+        text = "\n".join(pages)
+        if not text.strip():
+            return False
+        dest_path.write_text(text, encoding="utf-8")
+        return True
+    except Exception as e:
+        _log_error(f"Failed to extract Guidelines PDF: {e}")
+        return False
 
 
 def _scrape_epo_guidelines_html(dest_path: Path) -> bool:
@@ -379,9 +421,26 @@ def check_epo_pct_sources(dest_dir: Path) -> dict[str, bool]:
         Dict mapping document name to availability
     """
     return {
-        "epc": (dest_dir / EPC_FILE).exists(),
-        "epo_guidelines": (dest_dir / EPO_GUIDELINES_FILE).exists(),
-        "pct_treaty": (dest_dir / PCT_TREATY_FILE).exists(),
-        "pct_rules": (dest_dir / PCT_RULES_FILE).exists(),
-        "pct_guidelines": (dest_dir / PCT_GUIDELINES_FILE).exists(),
+        "epc": _source_present(dest_dir / EPC_FILE),
+        "epo_guidelines": _source_present(dest_dir / EPO_GUIDELINES_FILE),
+        "pct_treaty": _source_present(dest_dir / PCT_TREATY_FILE),
+        "pct_rules": _source_present(dest_dir / PCT_RULES_FILE),
+        "pct_guidelines": _source_present(dest_dir / PCT_GUIDELINES_FILE),
     }
+
+
+def _source_present(path: Path) -> bool:
+    """A source counts as present only if it is what it claims to be.
+
+    The old EPC URL saved a WIPO HTML page as epc_convention.pdf; treating
+    that artifact as present would block the corrected download forever.
+    """
+    if not path.exists():
+        return False
+    if path.suffix.lower() != ".pdf":
+        return True
+    try:
+        with path.open("rb") as f:
+            return f.read(5) == b"%PDF-"
+    except OSError:
+        return False

--- a/tests/test_epo_corpus_setup.py
+++ b/tests/test_epo_corpus_setup.py
@@ -1,0 +1,142 @@
+"""EPO/PCT corpus wiring into setup (issue #49) and honest downloads.
+
+The old EPC URL served a WIPO HTML page; _download_file saved it as
+epc_convention.pdf and reported success, so a fresh install carried a
+28 KB HTML file where the Convention should be and the index build would
+feed HTML to PyMuPDF. Downloads that claim a .pdf must BE a PDF, presence
+checks must not be fooled by the corrupt artifact, and setup must actually
+fetch the corpus (nothing ever called the downloaders — issue #49).
+"""
+
+
+import pytest
+
+from mcp_server import epo_downloaders as ed
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size):
+        yield from (
+            self._body[i : i + chunk_size]
+            for i in range(0, len(self._body), chunk_size)
+        )
+
+
+def test_download_file_rejects_html_masquerading_as_pdf(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        ed.requests, "get", lambda url, **kw: _FakeResponse(b"<!DOCTYPE html><html>nope</html>")
+    )
+    dest = tmp_path / "epc_convention.pdf"
+
+    ok = ed._download_file("https://example.test/x", dest, "EPC test")
+
+    assert ok is False
+    assert not dest.exists(), "corrupt download must not be left on disk"
+
+
+def test_download_file_accepts_real_pdf(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        ed.requests, "get", lambda url, **kw: _FakeResponse(b"%PDF-1.7 fake body" * 10)
+    )
+    dest = tmp_path / "epc_convention.pdf"
+
+    ok = ed._download_file("https://example.test/x", dest, "EPC test")
+
+    assert ok is True
+    assert dest.read_bytes().startswith(b"%PDF-")
+
+
+def test_check_sources_treats_html_pdf_as_missing(tmp_path):
+    (tmp_path / "epc_convention.pdf").write_bytes(b"<!DOCTYPE html>oops")
+    (tmp_path / "pct_treaty.pdf").write_bytes(b"%PDF-1.6 real")
+
+    status = ed.check_epo_pct_sources(tmp_path)
+
+    assert status["epc"] is False, "HTML saved as .pdf is not a present source"
+    assert status["pct_treaty"] is True
+
+
+def test_epc_url_points_at_a_pdf_endpoint():
+    assert ed.EPC_DOWNLOAD_URL.lower().endswith(".pdf"), (
+        "the old wipolex page URL served HTML; the EPC source must be a "
+        "direct PDF link"
+    )
+
+
+def test_guidelines_pdf_becomes_canonical_text_file(tmp_path):
+    """The index build reads epo_guidelines.txt only; a downloaded PDF must
+    be extracted into it or it is never indexed and never satisfies the
+    presence check (setup would re-download 10+ MB every run)."""
+    fitz = pytest.importorskip("fitz")
+    pdf_path = tmp_path / "epo_guidelines_2026.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "PART A - FORMALITIES EXAMINATION")
+    doc.save(str(pdf_path))
+    doc.close()
+    dest = tmp_path / "epo_guidelines.txt"
+
+    ok = ed._pdf_to_guidelines_text(pdf_path, dest)
+
+    assert ok is True
+    assert "FORMALITIES EXAMINATION" in dest.read_text(encoding="utf-8")
+
+
+def test_setup_helper_downloads_only_missing_sources(tmp_path, monkeypatch):
+    from mcp_server import cli
+
+    calls = []
+    monkeypatch.setattr(
+        cli, "check_epo_pct_sources",
+        lambda d: {"epc": False, "epo_guidelines": True, "pct_treaty": False,
+                   "pct_rules": True, "pct_guidelines": True},
+    )
+    monkeypatch.setattr(cli, "download_epc", lambda d: calls.append("epc") or True)
+    monkeypatch.setattr(cli, "scrape_epo_guidelines", lambda d: calls.append("guidelines") or True)
+    monkeypatch.setattr(cli, "download_pct_treaty", lambda d: calls.append("pct_treaty") or True)
+    monkeypatch.setattr(cli, "download_pct_rules", lambda d: calls.append("pct_rules") or True)
+    monkeypatch.setattr(cli, "download_pct_guidelines", lambda d: calls.append("pct_guidelines") or True)
+
+    got_new = cli._setup_epo_pct_sources(tmp_path)
+
+    assert got_new is True
+    assert calls == ["epc", "pct_treaty"], "only missing sources download"
+
+
+def test_setup_helper_is_best_effort(tmp_path, monkeypatch):
+    """EPO corpus problems must never block US setup."""
+    from mcp_server import cli
+
+    def boom(d):
+        raise RuntimeError("WIPO is down")
+
+    monkeypatch.setattr(
+        cli, "check_epo_pct_sources",
+        lambda d: {"epc": False, "epo_guidelines": False, "pct_treaty": False,
+                   "pct_rules": False, "pct_guidelines": False},
+    )
+    for name in ("download_epc", "scrape_epo_guidelines", "download_pct_treaty",
+                 "download_pct_rules", "download_pct_guidelines"):
+        monkeypatch.setattr(cli, name, boom)
+
+    got_new = cli._setup_epo_pct_sources(tmp_path)
+
+    assert got_new is False
+
+
+def test_setup_command_wires_epo_sources():
+    """setup and download-all must invoke the EPO/PCT corpus step."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    cli_src = (root / "mcp_server" / "cli.py").read_text(encoding="utf-8")
+    setup_body = cli_src.split("def setup_command", 1)[1].split("\ndef ", 1)[0]
+    download_all_body = cli_src.split("def download_all_command", 1)[1].split("\ndef ", 1)[0]
+    assert "_setup_epo_pct_sources" in setup_body
+    assert "_setup_epo_pct_sources" in download_all_body


### PR DESCRIPTION
Closes #49.

`epo_downloaders.py` existed but nothing ever invoked it, so a fresh install had no EPO/PCT corpus. Investigating the wiring surfaced three deeper problems, all fixed test-first:

1. **The EPC URL served HTML.** The WIPO wipolex link returns a webpage; `_download_file` saved it as `epc_convention.pdf` and reported success — the index build would feed HTML to PyMuPDF. Now: `EPC_DOWNLOAD_URL` points at the direct PDF the EPO's own legal-texts page publishes (live-verified: 6.3 MB, `%PDF` magic), `_download_file` validates magic bytes for .pdf destinations and discards non-PDF bodies, and `check_epo_pct_sources` treats HTML-as-.pdf as missing so poisoned installs self-heal.
2. **The Guidelines PDF path stranded its download.** On success it saved `epo_guidelines_<year>.pdf`, but the index build reads only `epo_guidelines.txt` and the presence check looks for the same — so the 10.8 MB PDF was never indexed and re-downloaded on every setup. Now extracted into the canonical text file (verified with real PyMuPDF).
3. **The wiring itself**: `setup` and `download-all` now run `_setup_epo_pct_sources` — checks all five sources, downloads only what's missing, best-effort by design (EPO/WIPO being unreachable never blocks US setup; the law-search tools already report missing corpora honestly per #48). Newly landed sources force an index rebuild so they actually become searchable.

Live verification of the full downloads: EPC 6.3 MB ✓, PCT Treaty 0.4 MB ✓, PCT Regulations 1.0 MB ✓, PCT Guidelines 1.5 MB ✓, EPO Guidelines 10.8 MB PDF ✓ → text.

8 new tests (one skips where PyMuPDF is absent); suite at 207 passing. I'll run the acceptance check — `search_patent_law(jurisdiction='EPO')` returning real EPC passages on the live install — after merge and report on the issue.