### PR TITLE
fix: index build crashed on EPO/PCT chunks missing 'page'

### DIFF
--- a/mcp_server/mpep_search.py
+++ b/mcp_server/mpep_search.py
@@ -226,6 +226,45 @@ class MPEPIndex:
             return f"MPEP {section}"
         return filename
 
+    @staticmethod
+    def _chunk_to_metadata(c: dict[str, Any]) -> dict[str, Any]:
+        """Normalize one extracted chunk into index metadata.
+
+        Every source's extractor produces a slightly different shape — the
+        EPO/PCT extractors (via _chunk_text_with_metadata) have no "page",
+        and hard-keying c["page"] here crashed the first index build that
+        included the EPO corpus. Missing fields get honest defaults; page
+        is None when the source has no page concept.
+        """
+        meta = {
+            "source": c.get("source", "MPEP"),
+            "file": c.get("file", ""),
+            "page": c.get("page"),
+            "section": c.get("section", c.get("source", "UNKNOWN")),
+            "has_statute": c.get("has_statute", False),
+            "has_mpep_ref": c.get("has_mpep_ref", False),
+            "has_rule_ref": c.get("has_rule_ref", False),
+            "is_statute": c.get("is_statute", False),
+            "is_regulation": c.get("is_regulation", False),
+            "is_update": c.get("is_update", False),
+        }
+        # Source-specific fields
+        if c.get("source") == "37_CFR":
+            meta["part"] = c.get("part")
+            meta["is_fee_schedule"] = c.get("is_fee_schedule", False)
+        elif c.get("source") == "SUBSEQUENT":
+            meta["doc_type"] = c.get("doc_type")
+            meta["fr_citation"] = c.get("fr_citation")
+            meta["effective_date"] = c.get("effective_date")
+            meta["mpep_sections_affected"] = c.get("mpep_sections_affected", [])
+            meta["supersedes_mpep"] = c.get("supersedes_mpep", False)
+        else:
+            # EPO/PCT structural fields, when the extractor recorded them
+            for key in ("part", "article", "rule"):
+                if key in c:
+                    meta[key] = c[key]
+        return meta
+
     def _chunk_text_with_metadata(
         self,
         text: str,
@@ -966,32 +1005,7 @@ class MPEPIndex:
 
         self.chunks = texts
         # Preserve all metadata from all source types
-        self.metadata = []
-        for c in all_chunks:
-            meta = {
-                "source": c.get("source", "MPEP"),
-                "file": c["file"],
-                "page": c["page"],
-                "section": c["section"],
-                "has_statute": c.get("has_statute", False),
-                "has_mpep_ref": c.get("has_mpep_ref", False),
-                "has_rule_ref": c.get("has_rule_ref", False),
-                "is_statute": c.get("is_statute", False),
-                "is_regulation": c.get("is_regulation", False),
-                "is_update": c.get("is_update", False),
-            }
-            # Add source-specific fields
-            if c.get("source") == "37_CFR":
-                meta["part"] = c.get("part")
-                meta["is_fee_schedule"] = c.get("is_fee_schedule", False)
-            elif c.get("source") == "SUBSEQUENT":
-                meta["doc_type"] = c.get("doc_type")
-                meta["fr_citation"] = c.get("fr_citation")
-                meta["effective_date"] = c.get("effective_date")
-                meta["mpep_sections_affected"] = c.get("mpep_sections_affected", [])
-                meta["supersedes_mpep"] = c.get("supersedes_mpep", False)
-
-            self.metadata.append(meta)
+        self.metadata = [self._chunk_to_metadata(c) for c in all_chunks]
 
         # Build BM25 index for hybrid search
         if BM25_AVAILABLE and BM25Okapi:

--- a/tests/test_index_metadata_assembly.py
+++ b/tests/test_index_metadata_assembly.py
@@ -1,0 +1,54 @@
+"""Index metadata assembly must accept every source's chunk shape.
+
+build_index hard-keyed c["page"]/c["file"]/c["section"], but the EPO/PCT
+extractors emit chunks via _chunk_text_with_metadata whose base metadata
+has no "page" — so the first rebuild after the #49 corpus wiring crashed
+with KeyError: 'page' and the EPO corpus could never be indexed.
+"""
+
+from mcp_server.mpep_search import MPEPIndex
+
+
+def test_mpep_chunk_keeps_its_fields():
+    meta = MPEPIndex._chunk_to_metadata(
+        {"source": "MPEP", "file": "mpep-2100.pdf", "page": 41,
+         "section": "MPEP 2100", "has_statute": True}
+    )
+    assert meta["file"] == "mpep-2100.pdf"
+    assert meta["page"] == 41
+    assert meta["section"] == "MPEP 2100"
+    assert meta["has_statute"] is True
+
+
+def test_epo_guidelines_chunk_without_page_is_accepted():
+    meta = MPEPIndex._chunk_to_metadata(
+        {"source": "EPO_GUIDELINES", "file": "epo_guidelines.txt",
+         "section": "EPO Guidelines Part A", "part": "Part A",
+         "is_statute": False}
+    )
+    assert meta["page"] is None
+    assert meta["section"] == "EPO Guidelines Part A"
+    assert meta["part"] == "Part A", "EPO part must survive into the index"
+
+
+def test_bare_chunk_never_raises():
+    meta = MPEPIndex._chunk_to_metadata({"source": "EPC"})
+    assert meta["file"] == ""
+    assert meta["page"] is None
+    assert meta["section"] == "EPC"
+
+
+def test_cfr_and_subsequent_fields_still_pass_through():
+    cfr = MPEPIndex._chunk_to_metadata(
+        {"source": "37_CFR", "file": "r.pdf", "page": 1, "section": "37 CFR 1.75",
+         "part": "1", "is_fee_schedule": True}
+    )
+    assert cfr["part"] == "1" and cfr["is_fee_schedule"] is True
+
+    sub = MPEPIndex._chunk_to_metadata(
+        {"source": "SUBSEQUENT", "file": "s.pdf", "page": 2, "section": "Updates",
+         "doc_type": "notice", "fr_citation": "89 FR 1", "effective_date": "2026-01-01",
+         "mpep_sections_affected": ["2173"], "supersedes_mpep": True}
+    )
+    assert sub["doc_type"] == "notice"
+    assert sub["mpep_sections_affected"] == ["2173"]


### PR DESCRIPTION
Found running #49's acceptance path on a live install: the first index rebuild that actually included the EPO/PCT corpus crashed with `KeyError: 'page'` at the metadata assembly in `build_index` — it hard-keyed `c['page']`/`c['file']`/`c['section']`, and chunks produced via `_chunk_text_with_metadata` (EPO Guidelines, EPC, PCT) have no `page`. The corpus wiring was untestable end-to-end until now because nothing ever downloaded the corpus (#49's original complaint), so this latent crash had never fired.

Fix: metadata assembly extracted into `MPEPIndex._chunk_to_metadata` (static, unit-testable) with honest defaults — `page: None` where the source has no page concept, empty file, section falling back to source — plus pass-through of EPO/PCT structural fields (`part`/`article`/`rule`). The crash happened before any index file was written, so no installed index was corrupted.

4 new tests; suite at 215 passing. Will re-run the live rebuild + `search_patent_law(jurisdiction='EPO')` acceptance after merge and report on #49's thread.