### PR TITLE
fix: filter source-scoped searches at retrieval, not after ranking

### DIFF
--- a/mcp_server/mpep_search.py
+++ b/mcp_server/mpep_search.py
@@ -227,6 +227,30 @@ class MPEPIndex:
         return filename
 
     @staticmethod
+    def _source_id_map(metadata: list[dict[str, Any]]) -> dict[str, Any]:
+        """Map each source label to the int64 chunk ids carrying it.
+
+        Used to restrict retrieval to one source BEFORE ranking — filtering
+        the global top-k afterwards degrades recall for minority sources
+        (45.7K MPEP chunks vs ~5K per EPO/PCT source; measured live, a
+        filtered EPC_RULES search returned 1 of 5 requested results).
+        """
+        by_source: dict[str, list[int]] = {}
+        for i, m in enumerate(metadata):
+            by_source.setdefault(m.get("source", "MPEP"), []).append(i)
+        return {s: np.asarray(ids, dtype=np.int64) for s, ids in by_source.items()}
+
+    @staticmethod
+    def _masked_bm25_top(scores: Any, allowed_ids: Any, k: int) -> Any:
+        """Top-k chunk ids by BM25 score, restricted to allowed_ids when given."""
+        scores = np.asarray(scores)
+        if allowed_ids is None:
+            return np.argsort(scores)[::-1][:k]
+        allowed_scores = scores[allowed_ids]
+        order = np.argsort(allowed_scores)[::-1][: min(k, len(allowed_ids))]
+        return allowed_ids[order]
+
+    @staticmethod
     def _chunk_to_metadata(c: dict[str, Any]) -> dict[str, Any]:
         """Normalize one extracted chunk into index metadata.
 
@@ -1006,6 +1030,7 @@ class MPEPIndex:
         self.chunks = texts
         # Preserve all metadata from all source types
         self.metadata = [self._chunk_to_metadata(c) for c in all_chunks]
+        self._source_ids_cache = None  # metadata changed; rebuild lazily
 
         # Build BM25 index for hybrid search
         if BM25_AVAILABLE and BM25Okapi:
@@ -1062,6 +1087,33 @@ class MPEPIndex:
         retrieve_k = min(top_k * 4, 50) if retrieve_k is None else min(retrieve_k, 100)
         candidates = {}
 
+        # Restrict retrieval to the requested source BEFORE ranking. The
+        # global candidate pool is dominated by MPEP chunks; filtering after
+        # the fact leaves jurisdiction-scoped searches with whatever scraps
+        # of the source survived the global cut (measured: 1 of 5).
+        allowed_ids = None
+        if source_filter:
+            cache = getattr(self, "_source_ids_cache", None)
+            if cache is None or getattr(self, "_source_ids_len", -1) != len(self.metadata):
+                self._source_ids_cache = cache = self._source_id_map(self.metadata)
+                self._source_ids_len = len(self.metadata)
+            allowed_ids = cache.get(source_filter)
+            if allowed_ids is None or len(allowed_ids) == 0:
+                # Source not indexed at all — nothing to retrieve; callers
+                # (patent_law_tools) report the missing corpus honestly.
+                allowed_ids = np.asarray([], dtype=np.int64)
+        sel_params = None
+        if allowed_ids is not None and len(allowed_ids):
+            try:
+                sel_params = faiss.SearchParameters(  # type: ignore[union-attr]
+                    sel=faiss.IDSelectorBatch(allowed_ids)  # type: ignore[union-attr]
+                )
+            except Exception:
+                # Very old faiss without search-time selectors: the BM25 leg
+                # is still exactly filtered and the post-filter below keeps
+                # correctness (with the old recall limits) for vectors.
+                sel_params = None
+
         # HyDE Query Expansion (if enabled)
         queries_to_search = [query]
         if self.use_hyde and self.hyde_expander:
@@ -1075,6 +1127,9 @@ class MPEPIndex:
             except Exception as e:
                 _log_warning(f"HyDE expansion failed: {e}, using original query", error=str(e))
 
+        if allowed_ids is not None and len(allowed_ids) == 0:
+            queries_to_search = []
+
         # Search with each query variant (original + hypothetical docs)
         for query_idx, search_query in enumerate(queries_to_search):
             query_weight = 1.0 if query_idx == 0 else 0.5  # Weight original query higher
@@ -1082,12 +1137,21 @@ class MPEPIndex:
             # Vector search with BGE query prefix (recommended format)
             query_with_prefix = f"query: {search_query}"
             query_embedding = self.model.encode([query_with_prefix])
-            vec_distances, vec_indices = self.index.search(  # type: ignore[union-attr]
-                query_embedding.astype("float32"), retrieve_k
-            )
+            if sel_params is not None:
+                vec_distances, vec_indices = self.index.search(  # type: ignore[union-attr]
+                    query_embedding.astype("float32"), retrieve_k, params=sel_params
+                )
+            else:
+                vec_distances, vec_indices = self.index.search(  # type: ignore[union-attr]
+                    query_embedding.astype("float32"), retrieve_k
+                )
 
             # Add vector search results with RRF scoring
             for rank, (idx, dist) in enumerate(zip(vec_indices[0], vec_distances[0])):
+                if idx < 0:
+                    # Selector-filtered search pads with -1 when fewer than
+                    # retrieve_k chunks carry the source.
+                    continue
                 rrf_contribution = query_weight * (1.0 / (60 + rank + 1))
 
                 if idx in candidates:
@@ -1107,7 +1171,7 @@ class MPEPIndex:
             if self.bm25:
                 tokenized_query = search_query.lower().split()
                 bm25_scores = self.bm25.get_scores(tokenized_query)
-                bm25_top_indices = np.argsort(bm25_scores)[::-1][:retrieve_k]  # type: ignore[union-attr]
+                bm25_top_indices = self._masked_bm25_top(bm25_scores, allowed_ids, retrieve_k)
 
                 for rank, idx in enumerate(bm25_top_indices):
                     rrf_contribution = query_weight * (1.0 / (60 + rank + 1))

--- a/tests/test_source_filtered_retrieval.py
+++ b/tests/test_source_filtered_retrieval.py
@@ -1,0 +1,55 @@
+"""Source-filtered search must filter at retrieval, not after ranking.
+
+search() retrieved the global top retrieve_k (<=50) candidates from the
+whole unified index and only then applied source_filter. With 45.7K MPEP
+chunks versus ~5K per EPO/PCT source, minority-source candidates get
+squeezed out of the global cut: measured on a live fully-indexed corpus,
+a source-filtered EPC_RULES search returned 1 of the 5 requested results.
+Restricting retrieval to the allowed ids up front makes filtered recall
+exact instead of query-dependent.
+"""
+
+import numpy as np
+
+from mcp_server.mpep_search import MPEPIndex
+
+
+def test_source_id_map_groups_by_source():
+    metadata = [
+        {"source": "MPEP"},
+        {"source": "EPC_RULES"},
+        {"source": "MPEP"},
+        {"source": "EPO_GUIDELINES"},
+        {"source": "EPC_RULES"},
+    ]
+    id_map = MPEPIndex._source_id_map(metadata)
+    assert id_map["MPEP"].tolist() == [0, 2]
+    assert id_map["EPC_RULES"].tolist() == [1, 4]
+    assert id_map["EPO_GUIDELINES"].tolist() == [3]
+    assert id_map["EPC_RULES"].dtype == np.int64
+
+
+def test_masked_bm25_top_returns_only_allowed_indices():
+    scores = np.array([9.0, 1.0, 8.0, 7.0, 0.5])
+    allowed = np.array([1, 3, 4], dtype=np.int64)
+
+    top = MPEPIndex._masked_bm25_top(scores, allowed, k=2)
+
+    assert top.tolist() == [3, 1], "highest-scoring ALLOWED indices, in order"
+
+
+def test_masked_bm25_top_without_mask_is_global():
+    scores = np.array([1.0, 5.0, 3.0])
+
+    top = MPEPIndex._masked_bm25_top(scores, None, k=2)
+
+    assert top.tolist() == [1, 2]
+
+
+def test_masked_bm25_top_handles_k_larger_than_allowed():
+    scores = np.array([1.0, 5.0, 3.0, 2.0])
+    allowed = np.array([0], dtype=np.int64)
+
+    top = MPEPIndex._masked_bm25_top(scores, allowed, k=10)
+
+    assert top.tolist() == [0]


### PR DESCRIPTION
Found while running #49's acceptance on the live install (68,516 chunks, EPO/PCT corpus indexed).

**What was wrong:** `search()` retrieved the global top `retrieve_k` (≤50) candidates across the entire unified index and only then applied `source_filter`. MPEP's 45.7K chunks dominate the global cut, so minority sources lose recall — measured live: a filtered `EPC_RULES` search returned **1 of the 5** requested results. (For honesty's sake: an earlier report of "0 results through the MCP boundary" turned out to be a bug in my acceptance driver — `search_patent_law` returns a list, which FastMCP splits into multiple content blocks. The recall starvation is real but partial, and query-dependent.)

**Fix:** retrieval is restricted to the source's chunk ids up front — FAISS searches with an `IDSelectorBatch` (verified supported on faiss 1.14.3; falls back to the old post-filter path on ancient faiss), and the BM25 leg argsorts only the allowed ids. Unknown/unindexed sources short-circuit to empty so `search_patent_law`'s honest missing-corpus message (#48) still fires. The source→ids map is cached and invalidated on rebuild.

**Live acceptance after this fix** (through the real MCP server): `search_patent_law(jurisdiction='EPO', query='inventive step requirements')` → 5 results incl. EPO Guidelines Part G-VII inventive-step annex; `jurisdiction='PCT'` → PCT Art. 17 and Rule 43 (international search report). #49's acceptance criterion is met.

4 new tests; suite at 219 passing.