### PR TITLE
setup: surface the Claude Code skills plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,19 @@ patent-creator check-bigquery    # Test BigQuery connection
 | `get_uspto_patent` | Get patent details from USPTO |
 | `get_recent_uspto_patents` | Pull recent filings |
 
+### Getting the campaign workflow (skills)
+
+The MCP server above gives Claude the TOOLS. The campaign workflow — the
+skill that runs mining, prior art, worth-it economics, drafting, and the
+red teams end to end — ships as a Claude Code plugin. Two commands:
+
+```bash
+claude plugin marketplace add RobThePCGuy/Claude-Patent-Creator
+claude plugin install claude-patent-creator-standalone@claude-patent-creator
+```
+
+Re-run the install command after upgrades to refresh the skills.
+
 ### Analysis
 
 | Tool | What it does |

--- a/mcp_server/cli.py
+++ b/mcp_server/cli.py
@@ -737,6 +737,23 @@ def setup_command(args):
         print("\n[WARNING] MCP server auto-registration failed", file=sys.stderr)
         print("  See manual registration command above", file=sys.stderr)
 
+    # The skills (incl. the patent-application-creator campaign workflow)
+    # ship as a Claude Code plugin, NOT inside this Python package — without
+    # these two commands a user gets the tools but never the campaign.
+    print("\nClaude Code skills (patent campaign workflow):", file=sys.stderr)
+    print(
+        "  claude plugin marketplace add RobThePCGuy/Claude-Patent-Creator",
+        file=sys.stderr,
+    )
+    print(
+        "  claude plugin install claude-patent-creator-standalone@claude-patent-creator",
+        file=sys.stderr,
+    )
+    print(
+        "  (re-run the install command after upgrades to refresh the skills)",
+        file=sys.stderr,
+    )
+
     # Check BigQuery status for final message
     bq_works = False
     try:


### PR DESCRIPTION
Found on a real installed machine: the MCP server was registered and every tool worked, but **zero skills were installed** — the campaign workflow (including the new worth-it gates from #71/#72) only exists in the repo's `.claude-plugin/`, and neither setup nor the README ever mentioned the plugin commands. The product promise is "the install gives Claude the skill"; in practice pip delivered tools only.

- Setup's final status now prints the two commands (`claude plugin marketplace add RobThePCGuy/Claude-Patent-Creator` + `claude plugin install claude-patent-creator-standalone@claude-patent-creator`) with a re-run-after-upgrades note.
- README gets a "Getting the campaign workflow (skills)" section between the MCP setup and the tool tables.

Verified the plugin path end-to-end on this machine: marketplace add → install → the cached `patent-application-creator/SKILL.md` carries the worth-it gates.

Suite untouched at 219.