### PR TITLE
fix: plugin version delivery — bump to 1.1.0 and CI-guard it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "USPTO patent creation and analysis system with hybrid RAG search, BigQuery access to 100M+ patents, automated compliance checking, prior art search, and diagram generation.",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "claude-patent-creator-standalone",
       "source": "./",
       "description": "Complete self-contained patent creation system - NO MCP server required. Uses Claude Code skills, agents, commands, and hooks.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "RobThePCGuy"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,5 +17,6 @@
     "patent-search",
     "bigquery",
     "diagrams"
-  ]
+  ],
+  "version": "1.1.0"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,35 @@ permissions:
   contents: read
 
 jobs:
+  plugin-version-guard:
+    # Merged skill/agent/command changes reach installed users only through
+    # `claude plugin update`, which compares versions — a PR that changes
+    # plugin content without bumping the version ships to nobody, silently.
+    name: Plugin version bumped when plugin content changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Require version bump for plugin-content changes
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          git fetch -q origin "${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- skills/ agents/ commands/ hooks/ | wc -l)
+          if [ "$CHANGED" -eq 0 ]; then
+            echo "No plugin content changed; guard passes."
+            exit 0
+          fi
+          if git diff "$BASE"...HEAD -- .claude-plugin/marketplace.json | grep -q '"version"'; then
+            echo "Plugin content changed and marketplace version bumped; guard passes."
+            exit 0
+          fi
+          echo "::error::skills/agents/commands/hooks changed but .claude-plugin/marketplace.json version did not."
+          echo "Bump the version in .claude-plugin/marketplace.json (and plugin.json) or installed users never receive this change."
+          exit 1
+
   lint-and-test:
     name: Lint, type-check, and test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Found live: PR #74 merged the Phase 1-H skill addition, then `claude plugin update` reported "already at the latest version (1.0.0)" and the installed cache verifiably lacked the change. The plugin version was pinned at 1.0.0 since day one — **every merged skill improvement has been unreachable by installed users**, silently.

- Version bumped to 1.1.0 in `.claude-plugin/marketplace.json` (both fields) and added to `.claude-plugin/plugin.json`. This release delivers the worth-it gates (#71/#72), the package red-team discipline (#59), and Phase 1-H history mining (#74) to plugin users.
- New CI job `plugin-version-guard`: a PR that touches `skills/ agents/ commands/ hooks/` without a version change in the marketplace manifest fails with an explanation. Same failure class as the stale verification stamp — content changed, version said otherwise — now machine-enforced.

Suite untouched at 219.