### PR TITLE
fix(security): stop logging key/project values; parse HTML with bs4

### DIFF
--- a/mcp_server/epo_downloaders.py
+++ b/mcp_server/epo_downloaders.py
@@ -6,7 +6,6 @@ Downloads legal documents for the European Patent Office (EPO) and
 Patent Cooperation Treaty (PCT) systems for indexing in the RAG pipeline.
 """
 
-import re
 import sys
 import time
 from pathlib import Path
@@ -18,6 +17,13 @@ try:
     REQUESTS_AVAILABLE = True
 except ImportError:
     REQUESTS_AVAILABLE = False
+
+try:
+    from bs4 import BeautifulSoup
+
+    BS4_AVAILABLE = True
+except ImportError:
+    BS4_AVAILABLE = False
 
 try:
     from logging_config import get_logger
@@ -341,38 +347,38 @@ def _extract_text_from_html(html: str) -> str:
     Returns:
         Extracted plain text
     """
-    # Remove script and style elements
-    html = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
-    html = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    if not BS4_AVAILABLE:
+        raise ImportError("beautifulsoup4 is required for HTML text extraction")
+
+    soup = BeautifulSoup(html, "lxml")
+
+    # Drop script/style bodies entirely; a real parser also handles the
+    # malformed closers (e.g. "</script >") that defeat regex filters.
+    for tag in soup(["script", "style"]):
+        tag.decompose()
 
     # Convert headings to text with markers
-    html = re.sub(r"<h1[^>]*>(.*?)</h1>", r"\n\n## \1\n", html, flags=re.DOTALL | re.IGNORECASE)
-    html = re.sub(r"<h2[^>]*>(.*?)</h2>", r"\n\n### \1\n", html, flags=re.DOTALL | re.IGNORECASE)
-    html = re.sub(r"<h3[^>]*>(.*?)</h3>", r"\n\n#### \1\n", html, flags=re.DOTALL | re.IGNORECASE)
-    html = re.sub(r"<h[4-6][^>]*>(.*?)</h[4-6]>", r"\n\1\n", html, flags=re.DOTALL | re.IGNORECASE)
+    for name, marker in (("h1", "\n\n## "), ("h2", "\n\n### "), ("h3", "\n\n#### ")):
+        for tag in soup.find_all(name):
+            tag.insert_before(marker)
+            tag.insert_after("\n")
+    for tag in soup.find_all(["h4", "h5", "h6"]):
+        tag.insert_before("\n")
+        tag.insert_after("\n")
 
-    # Convert paragraphs and line breaks
-    html = re.sub(r"<br\s*/?>", "\n", html, flags=re.IGNORECASE)
-    html = re.sub(r"<p[^>]*>", "\n\n", html, flags=re.IGNORECASE)
-    html = re.sub(r"</p>", "", html, flags=re.IGNORECASE)
+    # Convert paragraphs, line breaks, and list items
+    for tag in soup.find_all("br"):
+        tag.replace_with("\n")
+    for tag in soup.find_all("p"):
+        tag.insert_before("\n\n")
+    for tag in soup.find_all("li"):
+        tag.insert_before("\n- ")
 
-    # Convert list items
-    html = re.sub(r"<li[^>]*>", "\n- ", html, flags=re.IGNORECASE)
-
-    # Remove all remaining HTML tags
-    html = re.sub(r"<[^>]+>", "", html)
-
-    # Decode HTML entities
-    html = html.replace("&amp;", "&")
-    html = html.replace("&lt;", "<")
-    html = html.replace("&gt;", ">")
-    html = html.replace("&quot;", '"')
-    html = html.replace("&#39;", "'")
-    html = html.replace("&nbsp;", " ")
+    # get_text() drops remaining tags and decodes entities
 
     # Clean up whitespace
     lines = []
-    for line in html.split("\n"):
+    for line in soup.get_text().split("\n"):
         line = line.strip()
         if line:
             lines.append(line)

--- a/scripts/test_bigquery.py
+++ b/scripts/test_bigquery.py
@@ -27,7 +27,6 @@ def test_bigquery_availability():
 
         if status.get("available"):
             print("[OK] BigQuery is ready!")
-            print(f"  Project: {status.get('project')}")
             print(f"  Message: {status.get('message')}")
             if "us_patents" in status:
                 print(f"  US Patents accessible: {status.get('us_patents'):,}")

--- a/scripts/test_bigquery_logging.py
+++ b/scripts/test_bigquery_logging.py
@@ -40,7 +40,7 @@ def test_bigquery_initialization():
 
         if searcher.client:
             print("  [OK] BigQuery client initialized successfully")
-            print(f"  [OK] Billing project: {searcher.billing_project}")
+            print("  [OK] Billing project configured")
         else:
             print("  [WARN] BigQuery client not initialized (credentials not configured)")
 

--- a/scripts/test_bq_simple.py
+++ b/scripts/test_bq_simple.py
@@ -15,8 +15,12 @@ try:
     status = searcher.check_availability()
 
     print("\nStatus:")
-    for key, value in status.items():
-        print(f"  {key}: {value}")
+    # Named fields only — status["project"] flows from the ADC credentials
+    # file and code scanning flags echoing it.
+    print(f"  available: {status.get('available')}")
+    for field in ("message", "error", "install_command", "total_rows"):
+        if field in status:
+            print(f"  {field}: {status[field]}")
 
 except Exception as e:
     print(f"Error: {e}")

--- a/scripts/test_uspto_odp_api.py
+++ b/scripts/test_uspto_odp_api.py
@@ -115,7 +115,7 @@ def main():
     # Get API key from environment
     api_key = os.getenv("USPTO_API_KEY")
     if api_key:
-        print(f"API Key found: {api_key[:10]}..." if len(api_key) > 10 else "API Key found")
+        print("API Key found")
     else:
         print("[WARNING] No USPTO_API_KEY environment variable found")
         print("   Some endpoints may require authentication")

--- a/tests/test_epo_html_extraction.py
+++ b/tests/test_epo_html_extraction.py
@@ -1,0 +1,41 @@
+"""_extract_text_from_html moved from regex tag-stripping to a real HTML
+parser (bs4/lxml): regex filters miss malformed closers like ``</script >``
+and leave script bodies in the extracted "text" (CodeQL py/bad-tag-filter).
+These pin the security-relevant behavior and the structure markers.
+"""
+
+from mcp_server import epo_downloaders as ed
+
+
+def test_script_and_style_bodies_dropped_even_with_malformed_closers():
+    html = (
+        "<html><head><style>p { color: red }</style></head><body>"
+        "<script>var direct = 1;</script>"
+        '<script type="text/javascript">var sneaky = 2;</script  >'
+        "<p>Real content</p></body></html>"
+    )
+
+    text = ed._extract_text_from_html(html)
+
+    assert "direct" not in text
+    assert "sneaky" not in text, "malformed closer must not leak script body"
+    assert "color" not in text
+    assert "Real content" in text
+
+
+def test_structure_markers_and_entities_survive():
+    html = (
+        "<h1>Part A</h1><h2>Chapter 1</h2><h3>Section</h3>"
+        "<p>Fees &amp; forms<br>second line</p>"
+        "<ul><li>one</li><li>two</li></ul>"
+    )
+
+    text = ed._extract_text_from_html(html)
+
+    assert "## Part A" in text
+    assert "### Chapter 1" in text
+    assert "#### Section" in text
+    assert "Fees & forms" in text
+    assert "second line" in text
+    assert "- one" in text
+    assert "- two" in text


### PR DESCRIPTION
Resolves 5 of the 7 open code-scanning alerts; the other 2 get dismissed as reasoned false positives (see below).

| Alert | Location | Action |
|---|---|---|
| #33 | scripts/test_uspto_odp_api.py:118 | Stop printing a USPTO_API_KEY prefix — presence only. The real finding. |
| #31 | scripts/test_bq_simple.py:19 | Print named status fields; never echo `project` (flows from the ADC credentials file) |
| #23 | scripts/test_bigquery.py:30 | Drop the project-id echo |
| #28 | scripts/test_bigquery_logging.py:43 | Report "billing project configured" without the value |
| #1 | mcp_server/epo_downloaders.py:345 | Replace regex tag-stripping with BeautifulSoup/lxml (both already runtime deps). Regex filters miss malformed closers like `</script >` and leak script bodies into extracted text. New tests pin the bypass case and the heading/list/entity behavior. |

**Alerts #2 and #3** (cli.py:248, 1012) print the GCP billing project id in interactive setup/status output. Dismissing as false positive rather than code-fixing: a project id is a visible resource identifier (it appears in console URLs and gcloud output), not a credential — CodeQL flags it only because one fallback reads `quota_project_id` out of the ADC file. Masking it would hide exactly the thing a user checks during setup: which project gets billed.

Verified: ruff clean, compileall clean, EPO downloader tests pass locally including the two new ones.